### PR TITLE
[REFACTOR] 운영 컨테이너 로깅 관리 및 Actuator 설정 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 	implementation 'com.h2database:h2:2.2.220'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -48,7 +48,7 @@ services:
       - 8.8.8.8
       - 8.8.4.4
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:8080/api/health" ]
+      test: [ "CMD", "curl", "-f", "http://localhost:8080/actuator/health" ]
       interval: 30s
       timeout: 10s
       retries: 5
@@ -72,7 +72,7 @@ services:
       - 8.8.8.8
       - 8.8.4.4
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:8080/api/health" ]
+      test: [ "CMD", "curl", "-f", "http://localhost:8080/actuator/health" ]
       interval: 30s
       timeout: 10s
       retries: 5

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -49,3 +49,8 @@ kakao:
 
 firebase:
   admin-sdk: ${FIREBASE_ADMIN_SDK_PATH}
+
+logging:
+  level:
+    org.springframework.web.servlet.PageNotFound: ERROR
+    org.springframework.web.socket.config.WebSocketMessageBrokerStats: ERROR


### PR DESCRIPTION
## 🎋 작업중인 브랜치 및 이슈

- #16 


## 🔑 주요 변경사항

- 운영 환경에서 웹소켓과 헬스 체크 관련 로그 WARN 레벨 미만으로는 출력 안되도록 변경
- Actuator 서버 헬스 체크 추가


## Check List
- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 애플리케이션 상태 확인을 위한 헬스 체크 엔드포인트(/actuator/health) 제공으로 모니터링 강화.

- 작업
  - 프로덕션 Docker Compose의 backend-blue/green 헬스체크 타깃을 /api/health에서 /actuator/health로 업데이트.
  - 로깅 설정 조정: 특정 프레임워크 로그를 ERROR 수준으로 격상하여 불필요한 로그 노이즈 감소.
  - 구성 파일 정리 및 포매팅 개선(기존 동작에는 영향 없음).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->