### PR TITLE
[FIX] Spring AMQP 패키지 인식 범위 수정

### DIFF
--- a/src/main/java/com/gdg/z_meet/global/config/RabbitMqConfig.java
+++ b/src/main/java/com/gdg/z_meet/global/config/RabbitMqConfig.java
@@ -81,7 +81,7 @@ public class RabbitMqConfig {
     public org.springframework.amqp.support.converter.DefaultClassMapper classMapper() {
         org.springframework.amqp.support.converter.DefaultClassMapper classMapper = 
             new org.springframework.amqp.support.converter.DefaultClassMapper();
-        classMapper.setTrustedPackages("com.gdg.z_meet.*");
+        classMapper.setTrustedPackages("com.gdg.z_meet");
         return classMapper;
     }
 


### PR DESCRIPTION
## 🎋 작업중인 브랜치 및 이슈

-


## 🔑 주요 변경사항

- RabbitMQ Consumer에서 FcmMessageRequest 역직렬화 실패
- Spring AMQP는 와일드카드 패턴(`*`)을 지원하지 않아서, 하위 패키지 모두 자동으로 신뢰되도록 수정


## Check List
- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!