### PR TITLE
[FEATURE] 운영 서버 로깅 레벨(ERROR,FATAL) 알림 기능 추가

### DIFF
--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -19,6 +19,7 @@ services:
     container_name: grafana
     volumes:
       - grafana-storage:/var/lib/grafana
+      - ./monitoring/grafana/provisioning:/etc/grafana/provisioning
     environment:
       - GF_SECURITY_ADMIN_USER=${GRAFANA_USER}
       - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_PW}

--- a/monitoring/grafana/provisioning/alerting/alerts.yml
+++ b/monitoring/grafana/provisioning/alerting/alerts.yml
@@ -1,0 +1,53 @@
+apiVersion: 1
+
+groups:
+  - orgId: 1
+    name: error_alerts
+    folder: Logs
+    interval: 1m
+    rules:
+      - uid: error_fatal_alert
+        title: ERROR/FATAL Log Alert
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 300
+              to: 0
+            datasourceUid: loki
+            model:
+              expr: 'sum(count_over_time({container=~"backend-blue|backend-green|backend-worker"} |~ "ERROR|FATAL" !~ "Failed to send message to MessageChannel" [1m]))'
+              refId: A
+          - refId: C
+            relativeTimeRange:
+              from: 0
+              to: 0
+            datasourceUid: __expr__
+            model:
+              conditions:
+                - evaluator:
+                    params:
+                      - 1
+                    type: gt
+                  operator:
+                    type: and
+                  query:
+                    params:
+                      - C
+                  type: query
+              datasource:
+                type: __expr__
+                uid: __expr__
+              expression: A
+              reducer: last
+              type: reduce
+        noDataState: NoData
+        execErrState: Alerting
+        for: 1m
+        annotations:
+          description: 'ERROR 또는 FATAL 레벨 로그가 감지되었습니다.'
+          summary: '애플리케이션에서 심각한 에러가 발생했습니다.'
+        labels:
+          severity: critical
+        notificationSettings:
+          receiver: discord

--- a/monitoring/grafana/provisioning/alerting/contact-points.yml
+++ b/monitoring/grafana/provisioning/alerting/contact-points.yml
@@ -1,0 +1,18 @@
+apiVersion: 1
+
+contactPoints:
+  - orgId: 1
+    name: discord
+    receivers:
+      - uid: discord_webhook
+        type: discord
+        settings:
+          url: https://discord.com/api/webhooks/1422957628124037324/8PFtcGZBvzL94GplpxeBe2q63AkUOFgp5CtiHeAgyIeXVEsjXX8arWVIzpNvZOsu2oin
+          message: |
+            🚨 **ERROR/FATAL 로그 알림**
+            
+            **Summary:** {{ .CommonAnnotations.summary }}
+            **Description:** {{ .CommonAnnotations.description }}
+            
+            **시각:** {{ .StartsAt }}
+        disableResolveMessage: false

--- a/monitoring/grafana/provisioning/alerting/policies.yml
+++ b/monitoring/grafana/provisioning/alerting/policies.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+policies:
+  - orgId: 1
+    receiver: discord
+    group_by: ['alertname']
+    group_wait: 10s
+    group_interval: 10s
+    repeat_interval: 12h

--- a/monitoring/grafana/provisioning/datasources/loki.yml
+++ b/monitoring/grafana/provisioning/datasources/loki.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+datasources:
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    uid: loki
+    isDefault: false
+    editable: true


### PR DESCRIPTION
## 🎋 작업중인 브랜치 및 이슈

-


## 🔑 주요 변경사항

- Promtail이 수집한 로그 데이터를 Grafana 에서 체킹 => ERROR & FATAL 로그에 대한 알림


## Check List
- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - Grafana 경고 프로비저닝 추가: 오류 로그 감지 알림(1분 간격, 심각도 critical), NoData/실행 오류 처리, Discord 알림 연동.
  - 알림 정책 구성: alertname 기준 그룹화, 그룹 대기 10초, 그룹 간격 10초, 반복 12시간.
  - Loki 데이터 소스 자동 등록 및 사용 준비.
- Chores
  - 모니터링용 docker-compose에 Grafana 프로비저닝 디렉터리 마운트 추가로 자동 설정 적용.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->