### PR TITLE
[FIX] 운영 중 발생한 동시성 이슈 대응 및 토큰 저장 플로우 개선

### DIFF
--- a/src/main/java/com/gdg/z_meet/domain/fcm/repository/FcmTokenRepository.java
+++ b/src/main/java/com/gdg/z_meet/domain/fcm/repository/FcmTokenRepository.java
@@ -2,8 +2,11 @@ package com.gdg.z_meet.domain.fcm.repository;
 
 import com.gdg.z_meet.domain.fcm.entity.FcmToken;
 import com.gdg.z_meet.domain.user.entity.User;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -19,6 +22,10 @@ public interface FcmTokenRepository extends JpaRepository<FcmToken, Long> {
 
     @Query(" SELECT ft FROM FcmToken ft JOIN FETCH ft.user u WHERE u.pushAgree = true")
     List<FcmToken> findAllByUserPushAgreeTrue();
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT f FROM FcmToken f WHERE f.user = :user")
+    Optional<FcmToken> findByUserForUpdate(@Param("user") User user);
 
     void deleteByUser(User user);
 


### PR DESCRIPTION
## 🎋 작업중인 브랜치 및 이슈

-


## 🔑 주요 변경사항
[대응 과정 정리]
https://generated-bush-cff.notion.site/FCM-Token-Race-Condition-280303e2522280ac83e4ea3a55fea074?source=copy_link

Unique 제약이 걸려있었음에도 운영 중 FCM Token 중복 Row 발생하여, 로그인 시 500 에러

- 기존 토큰을 delete + flush 후 새로 저장하는 플로우로 변경
- Race Condition 대응 → findByUserForUpdate 에 비관적 락(쓰기)을 통해 트랜잭션 간 동시 읽기·쓰기 차단


## Check List
- [ ] **Assignees** 등록을 하였나요?
- [ ] **라벨(Label)** 등록을 하였나요?
- [ ] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!