### PR TITLE
[REFACTOR] JPQL 서브쿼리 -> QueryDSL & 인덱스 최적화 및 통합 테스트 검증

### DIFF
--- a/src/main/java/com/gdg/z_meet/domain/user/entity/User.java
+++ b/src/main/java/com/gdg/z_meet/domain/user/entity/User.java
@@ -114,4 +114,14 @@ public class User extends BaseEntity implements UserDetails {
             fcmToken.setUser(this);
         }
     }
+
+    public void setPhoneNumber(String phoneNumber) {
+    }
+
+    public void setName(String name) {
+    }
+
+    public void setStudentNumber(String studentNumber) {
+        
+    }
 }

--- a/src/main/java/com/gdg/z_meet/domain/user/entity/User.java
+++ b/src/main/java/com/gdg/z_meet/domain/user/entity/User.java
@@ -116,12 +116,14 @@ public class User extends BaseEntity implements UserDetails {
     }
 
     public void setPhoneNumber(String phoneNumber) {
+        this.phoneNumber = phoneNumber;
     }
 
     public void setName(String name) {
+        this.name = name;
     }
 
     public void setStudentNumber(String studentNumber) {
-        
+        this.studentNumber = studentNumber;
     }
 }

--- a/src/main/java/com/gdg/z_meet/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/gdg/z_meet/domain/user/repository/UserRepository.java
@@ -13,7 +13,7 @@ import java.util.List;
 import java.util.Optional;
 
 @Repository
-public interface UserRepository extends JpaRepository<User, Long> {
+public interface UserRepository extends JpaRepository<User, Long>, UserRepositoryCustom {
 
     Optional<User> findByStudentNumber(String studentNumber);
     Optional<User> findById(Long userId);
@@ -23,22 +23,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     @Query("SELECT u FROM User u JOIN FETCH u.userProfile WHERE u.id IN :userIds")
     List<User> findAllByIdWithProfile(@Param("userIds") List<Long> userIds);
-
-    @Query("SELECT u FROM User u JOIN FETCH u.userProfile up WHERE up.gender = :gender " +
-            "AND up.nickname LIKE :nickname% AND u.id != :userId AND u.isDeleted = false " +
-            "AND NOT EXISTS (SELECT 1 FROM Team t JOIN UserTeam ut ON ut.team = t " +
-            "WHERE ut.user = u AND t.teamType = :teamType AND t.activeStatus = 'ACTIVE' AND t.event = :event)")
-    List<User> findAllByNicknameWithProfile(@Param("gender") Gender gender, @Param("nickname") String nickname,
-                                            @Param("userId") Long userId, @Param("teamType") TeamType teamType,
-                                            @Param("event") Event event);
-
-    @Query("SELECT u FROM User u JOIN FETCH u.userProfile up WHERE up.gender = :gender " +
-            "AND u.phoneNumber LIKE :phoneNumber% AND u.id != :userId AND u.isDeleted = false " +
-            "AND NOT EXISTS (SELECT 1 FROM Team t JOIN UserTeam ut ON ut.team = t " +
-            "WHERE ut.user = u AND t.teamType = :teamType AND t.activeStatus = 'ACTIVE' AND t.event = :event)")
-    List<User> findAllByPhoneNumberWithProfile(@Param("gender") Gender gender, @Param("phoneNumber") String phoneNumber,
-                                               @Param("userId") Long userId, @Param("teamType") TeamType teamType,
-                                               @Param("event") Event event);
 
     boolean existsByStudentNumber(String studentNumber);
     boolean existsByPhoneNumber(String phoneNumber);

--- a/src/main/java/com/gdg/z_meet/domain/user/repository/UserRepositoryCustom.java
+++ b/src/main/java/com/gdg/z_meet/domain/user/repository/UserRepositoryCustom.java
@@ -1,0 +1,15 @@
+package com.gdg.z_meet.domain.user.repository;
+
+import com.gdg.z_meet.domain.meeting.entity.enums.Event;
+import com.gdg.z_meet.domain.meeting.entity.enums.TeamType;
+import com.gdg.z_meet.domain.user.entity.User;
+import com.gdg.z_meet.domain.user.entity.enums.Gender;
+
+import java.util.List;
+
+public interface UserRepositoryCustom {
+    
+    List<User> findAllByNicknameWithProfile(Gender gender, String nickname, Long userId, TeamType teamType, Event event);
+    
+    List<User> findAllByPhoneNumberWithProfile(Gender gender, String phoneNumber, Long userId, TeamType teamType, Event event);
+}

--- a/src/main/java/com/gdg/z_meet/domain/user/repository/UserRepositoryImpl.java
+++ b/src/main/java/com/gdg/z_meet/domain/user/repository/UserRepositoryImpl.java
@@ -1,0 +1,63 @@
+package com.gdg.z_meet.domain.user.repository;
+
+import com.gdg.z_meet.domain.meeting.entity.QTeam;
+import com.gdg.z_meet.domain.meeting.entity.QUserTeam;
+import com.gdg.z_meet.domain.meeting.entity.enums.ActiveStatus;
+import com.gdg.z_meet.domain.meeting.entity.enums.Event;
+import com.gdg.z_meet.domain.meeting.entity.enums.TeamType;
+import com.gdg.z_meet.domain.user.entity.QUser;
+import com.gdg.z_meet.domain.user.entity.QUserProfile;
+import com.gdg.z_meet.domain.user.entity.User;
+import com.gdg.z_meet.domain.user.entity.enums.Gender;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class UserRepositoryImpl implements UserRepositoryCustom {
+    
+    private final JPAQueryFactory queryFactory;
+    
+    @Override
+    public List<User> findAllByNicknameWithProfile(Gender gender, String nickname, Long userId, TeamType teamType, Event event) {
+        return findAllWithProfileCommon(gender, userId, teamType, event, QUserProfile.userProfile.nickname.startsWith(nickname));
+    }
+    
+    @Override
+    public List<User> findAllByPhoneNumberWithProfile(Gender gender, String phoneNumber, Long userId, TeamType teamType, Event event) {
+        return findAllWithProfileCommon(gender, userId, teamType, event, QUser.user.phoneNumber.startsWith(phoneNumber));
+    }
+    
+    private List<User> findAllWithProfileCommon(
+            Gender gender, Long userId, TeamType teamType, Event event,
+            BooleanExpression searchCondition
+    ) {
+        QUser user = QUser.user;
+        QUserProfile userProfile = QUserProfile.userProfile;
+        QUserTeam userTeam = QUserTeam.userTeam;
+        QTeam team = QTeam.team;
+        
+        return queryFactory
+                .selectFrom(user)
+                .join(user.userProfile, userProfile).fetchJoin()
+                .leftJoin(userTeam).on(userTeam.user.eq(user))
+                .leftJoin(team).on(
+                        userTeam.team.eq(team)
+                                .and(team.teamType.eq(teamType))
+                                .and(team.activeStatus.eq(ActiveStatus.ACTIVE))
+                                .and(team.event.eq(event))
+                )
+                .where(
+                        userProfile.gender.eq(gender),
+                        user.id.ne(userId),
+                        user.isDeleted.eq(false),
+                        searchCondition,
+                        team.id.isNull()
+                )
+                .fetch();
+    }
+}

--- a/src/main/java/com/gdg/z_meet/domain/user/repository/UserRepositoryImpl.java
+++ b/src/main/java/com/gdg/z_meet/domain/user/repository/UserRepositoryImpl.java
@@ -43,6 +43,7 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
         
         return queryFactory
                 .selectFrom(user)
+                .distinct()
                 .join(user.userProfile, userProfile).fetchJoin()
                 .leftJoin(userTeam).on(userTeam.user.eq(user))
                 .leftJoin(team).on(

--- a/src/test/java/com/gdg/z_meet/domain/user/repository/UserRepositoryQueryOptimizationTest.java
+++ b/src/test/java/com/gdg/z_meet/domain/user/repository/UserRepositoryQueryOptimizationTest.java
@@ -1,0 +1,480 @@
+package com.gdg.z_meet.domain.user.repository;
+
+import com.gdg.z_meet.domain.fcm.unit.config.QueryDslTestConfig;
+import com.gdg.z_meet.domain.meeting.entity.Team;
+import com.gdg.z_meet.domain.meeting.entity.UserTeam;
+import com.gdg.z_meet.domain.meeting.entity.enums.ActiveStatus;
+import com.gdg.z_meet.domain.meeting.entity.enums.Event;
+import com.gdg.z_meet.domain.meeting.entity.enums.TeamType;
+import com.gdg.z_meet.domain.meeting.repository.TeamRepository;
+import com.gdg.z_meet.domain.meeting.repository.UserTeamRepository;
+import com.gdg.z_meet.domain.user.entity.User;
+import com.gdg.z_meet.domain.user.entity.UserProfile;
+import com.gdg.z_meet.domain.user.entity.enums.*;
+import jakarta.persistence.EntityManager;
+import org.hibernate.SessionFactory;
+import org.hibernate.stat.Statistics;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
+@Import({UserRepositoryImpl.class, QueryDslTestConfig.class})
+@DisplayName("UserRepository QueryDSL 최적화 검증")
+class UserRepositoryQueryOptimizationTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private UserProfileRepository userProfileRepository;
+
+    @Autowired
+    private TeamRepository teamRepository;
+
+    @Autowired
+    private UserTeamRepository userTeamRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    private Statistics statistics;
+    private User testUser;
+
+    @BeforeEach
+    void setUp() {
+        SessionFactory sessionFactory = entityManager.getEntityManagerFactory()
+                .unwrap(SessionFactory.class);
+        statistics = sessionFactory.getStatistics();
+        statistics.setStatisticsEnabled(true);
+        statistics.clear();
+
+        testUser = createUser("2024001", "testUser", "010-1111-1111", "테스트", Gender.MALE);
+
+        for (int i = 0; i < 50; i++) {
+            User user = createUser(
+                    "2024" + String.format("%03d", i + 100),
+                    "user" + i,
+                    "010-2000-" + String.format("%04d", i),
+                    "유저" + i,
+                    Gender.FEMALE
+            );
+
+            // 10명은 활성 팀에 속하게 함
+            if (i % 5 == 0) {
+                Team team = createTeam(TeamType.TWO_TO_TWO, Event.NEUL_2025);
+                createUserTeam(user, team);
+            }
+        }
+
+        entityManager.flush();
+        entityManager.clear();
+        statistics.clear();
+    }
+
+    // 최적화 이전 JPQL 쿼리 (NOT EXISTS 서브쿼리 방식)
+    private List<User> findAllByNicknameWithProfileJpql(Gender gender, String nickname, Long userId, TeamType teamType, Event event) {
+        return entityManager.createQuery(
+                "SELECT u FROM User u JOIN FETCH u.userProfile up WHERE up.gender = :gender " +
+                        "AND up.nickname LIKE CONCAT(:nickname, '%') AND u.id != :userId AND u.isDeleted = false " +
+                        "AND NOT EXISTS (SELECT 1 FROM Team t JOIN UserTeam ut ON ut.team = t " +
+                        "WHERE ut.user = u AND t.teamType = :teamType AND t.activeStatus = 'ACTIVE' AND t.event = :event)",
+                User.class)
+                .setParameter("gender", gender)
+                .setParameter("nickname", nickname)
+                .setParameter("userId", userId)
+                .setParameter("teamType", teamType)
+                .setParameter("event", event)
+                .getResultList();
+    }
+
+    private List<User> findAllByPhoneNumberWithProfileJpql(Gender gender, String phoneNumber, Long userId, TeamType teamType, Event event) {
+        return entityManager.createQuery(
+                "SELECT u FROM User u JOIN FETCH u.userProfile up WHERE up.gender = :gender " +
+                        "AND u.phoneNumber LIKE CONCAT(:phoneNumber, '%') AND u.id != :userId AND u.isDeleted = false " +
+                        "AND NOT EXISTS (SELECT 1 FROM Team t JOIN UserTeam ut ON ut.team = t " +
+                        "WHERE ut.user = u AND t.teamType = :teamType AND t.activeStatus = 'ACTIVE' AND t.event = :event)",
+                User.class)
+                .setParameter("gender", gender)
+                .setParameter("phoneNumber", phoneNumber)
+                .setParameter("userId", userId)
+                .setParameter("teamType", teamType)
+                .setParameter("event", event)
+                .getResultList();
+    }
+
+    @Test
+    void JPQL_NOT_EXISTS_서브쿼리_방식_쿼리_실행_횟수_확인() {
+        // given
+        statistics.clear();
+        
+        // when: JPQL NOT EXISTS 방식
+        List<User> result = findAllByNicknameWithProfileJpql(
+                Gender.FEMALE,
+                "user",
+                testUser.getId(),
+                TeamType.TWO_TO_TWO,
+                Event.NEUL_2025
+        );
+
+        // then
+        long jpqlQueryCount = statistics.getQueryExecutionCount();
+        
+        assertThat(jpqlQueryCount)
+                .as("JPQL NOT EXISTS 방식의 쿼리 실행 횟수")
+                .isGreaterThanOrEqualTo(1);
+        
+        assertThat(result).hasSize(40);
+    }
+
+    @Test
+    void QueryDSL_LEFT_JOIN으로_NOT_EXISTS_서브쿼리_최적화() {
+        // given: 기존 JPQL은 NOT EXISTS 서브쿼리 사용
+        // 최적화: LEFT JOIN + IS NULL로 변경
+        
+        // when
+        List<User> result = userRepository.findAllByNicknameWithProfile(
+                Gender.FEMALE,
+                "user",
+                testUser.getId(),
+                TeamType.TWO_TO_TWO,
+                Event.NEUL_2025
+        );
+
+        // then: LEFT JOIN 방식은 단일 쿼리로 처리
+        assertThat(statistics.getQueryExecutionCount())
+                .as("LEFT JOIN 방식은 서브쿼리 없이 1번의 쿼리로 실행")
+                .isEqualTo(1);
+        
+        assertThat(result).hasSize(40); // 50명 중 활성 팀 10명 제외
+    }
+
+    @Test
+    void QueryDSL_JOIN_FETCH로_N플러스1_문제_해결() {
+        // given
+        statistics.clear();
+        
+        // when
+        List<User> result = userRepository.findAllByNicknameWithProfile(
+                Gender.FEMALE,
+                "user",
+                testUser.getId(),
+                TeamType.TWO_TO_TWO,
+                Event.NEUL_2025
+        );
+
+        long queriesBeforeAccess = statistics.getQueryExecutionCount();
+        
+        // UserProfile 접근 시 추가 쿼리가 발생하지 않아야 함
+        result.forEach(user -> {
+            String nickname = user.getUserProfile().getNickname();
+            assertThat(nickname).isNotNull();
+        });
+        
+        long queriesAfterAccess = statistics.getQueryExecutionCount();
+
+        // then
+        assertThat(queriesAfterAccess)
+                .as("JOIN FETCH로 인해 UserProfile 접근 시 추가 쿼리 없음")
+                .isEqualTo(queriesBeforeAccess);
+    }
+
+    @Test
+    void QueryDSL_활성_팀_필터링_정확성_검증() {
+        // when
+        List<User> result = userRepository.findAllByNicknameWithProfile(
+                Gender.FEMALE,
+                "user",
+                testUser.getId(),
+                TeamType.TWO_TO_TWO,
+                Event.NEUL_2025
+        );
+
+        // then: 활성 팀에 속하지 않은 사용자만 조회
+        result.forEach(user -> {
+            List<UserTeam> userTeams = userTeamRepository.findByUserId(user.getId());
+            boolean hasActiveTeam = userTeams.stream()
+                    .anyMatch(ut -> ut.getTeam().getActiveStatus() == ActiveStatus.ACTIVE
+                            && ut.getTeam().getTeamType() == TeamType.TWO_TO_TWO
+                            && ut.getTeam().getEvent() == Event.NEUL_2025);
+            
+            assertThat(hasActiveTeam)
+                    .as("LEFT JOIN + IS NULL 방식으로 활성 팀 소속 사용자 제외")
+                    .isFalse();
+        });
+    }
+
+    @Test
+    void QueryDSL_전화번호_검색도_동일한_최적화_적용() {
+        // when
+        List<User> result = userRepository.findAllByPhoneNumberWithProfile(
+                Gender.FEMALE,
+                "010-2000",
+                testUser.getId(),
+                TeamType.TWO_TO_TWO,
+                Event.NEUL_2025
+        );
+
+        // then
+        assertThat(statistics.getQueryExecutionCount())
+                .as("전화번호 검색도 LEFT JOIN 방식으로 단일 쿼리 실행")
+                .isEqualTo(1);
+        
+        assertThat(result).hasSize(40);
+    }
+
+    @Test
+    void QueryDSL_startsWith로_LIKE_패턴_최적화() {
+        // given
+        createUser("2024500", "abc123", "010-5000-0001", "ABC1", Gender.FEMALE);
+        createUser("2024501", "abc456", "010-5000-0002", "ABC2", Gender.FEMALE);
+        createUser("2024502", "xyz789", "010-5000-0003", "XYZ1", Gender.FEMALE);
+        
+        entityManager.flush();
+        entityManager.clear();
+        statistics.clear();
+        
+        // when
+        List<User> result = userRepository.findAllByNicknameWithProfile(
+                Gender.FEMALE,
+                "abc",
+                testUser.getId(),
+                TeamType.TWO_TO_TWO,
+                Event.NEUL_2025
+        );
+
+        // then: startsWith('abc') → LIKE 'abc%' 형태로 인덱스 활용 가능
+        assertThat(result).hasSize(2);
+        assertThat(result)
+                .extracting(u -> u.getUserProfile().getNickname())
+                .allMatch(nickname -> nickname.startsWith("abc"));
+    }
+
+    @Test
+    void QueryDSL_최적화_쿼리와_기존_로직_결과_동일성_검증() {
+        // when: QueryDSL 최적화 쿼리 실행
+        List<User> queryDslResult = userRepository.findAllByNicknameWithProfile(
+                Gender.FEMALE,
+                "user",
+                testUser.getId(),
+                TeamType.TWO_TO_TWO,
+                Event.NEUL_2025
+        );
+
+        // when: 동일한 조건으로 수동 필터링 (기대 결과)
+        List<User> allFemaleUsers = userRepository.findAll().stream()
+                .filter(u -> u.getUserProfile() != null)
+                .filter(u -> u.getUserProfile().getGender() == Gender.FEMALE)
+                .filter(u -> u.getUserProfile().getNickname().startsWith("user"))
+                .filter(u -> !u.getId().equals(testUser.getId()))
+                .filter(u -> !u.isDeleted())
+                .filter(u -> {
+                    List<UserTeam> teams = userTeamRepository.findByUserId(u.getId());
+                    return teams.stream().noneMatch(ut ->
+                            ut.getTeam().getTeamType() == TeamType.TWO_TO_TWO &&
+                            ut.getTeam().getActiveStatus() == ActiveStatus.ACTIVE &&
+                            ut.getTeam().getEvent() == Event.NEUL_2025
+                    );
+                })
+                .toList();
+
+        // then: 결과가 동일해야 함
+        assertThat(queryDslResult)
+                .as("QueryDSL 최적화 쿼리 결과가 기존 로직과 동일")
+                .hasSize(allFemaleUsers.size())
+                .extracting(User::getId)
+                .containsExactlyInAnyOrderElementsOf(
+                        allFemaleUsers.stream().map(User::getId).toList()
+                );
+    }
+
+    @Test
+    void JPQL과_QueryDSL_결과_동일성_검증() {
+        // when: JPQL 방식
+        List<User> jpqlResult = findAllByNicknameWithProfileJpql(
+                Gender.FEMALE,
+                "user",
+                testUser.getId(),
+                TeamType.TWO_TO_TWO,
+                Event.NEUL_2025
+        );
+
+        entityManager.clear();
+
+        // when: QueryDSL 방식
+        List<User> queryDslResult = userRepository.findAllByNicknameWithProfile(
+                Gender.FEMALE,
+                "user",
+                testUser.getId(),
+                TeamType.TWO_TO_TWO,
+                Event.NEUL_2025
+        );
+
+        // then: 두 방식의 결과가 동일해야 함
+        assertThat(jpqlResult)
+                .as("JPQL과 QueryDSL의 결과 개수가 동일")
+                .hasSameSizeAs(queryDslResult);
+
+        assertThat(jpqlResult)
+                .as("JPQL과 QueryDSL의 결과 ID가 동일")
+                .extracting(User::getId)
+                .containsExactlyInAnyOrderElementsOf(
+                        queryDslResult.stream().map(User::getId).toList()
+                );
+    }
+
+    @Test
+    void JPQL_대비_QueryDSL_쿼리_실행_횟수_비교() {
+        // given
+        entityManager.clear();
+        statistics.clear();
+
+        // when: JPQL 방식
+        findAllByNicknameWithProfileJpql(
+                Gender.FEMALE,
+                "user",
+                testUser.getId(),
+                TeamType.TWO_TO_TWO,
+                Event.NEUL_2025
+        );
+        long jpqlQueryCount = statistics.getQueryExecutionCount();
+
+        entityManager.clear();
+        statistics.clear();
+
+        // when: QueryDSL 방식
+        userRepository.findAllByNicknameWithProfile(
+                Gender.FEMALE,
+                "user",
+                testUser.getId(),
+                TeamType.TWO_TO_TWO,
+                Event.NEUL_2025
+        );
+        long queryDslQueryCount = statistics.getQueryExecutionCount();
+
+        // then: 쿼리 실행 횟수 비교
+        assertThat(queryDslQueryCount)
+                .as("QueryDSL LEFT JOIN 방식이 JPQL NOT EXISTS보다 효율적")
+                .isLessThanOrEqualTo(jpqlQueryCount);
+
+        assertThat(queryDslQueryCount)
+                .as("QueryDSL은 단일 쿼리로 실행")
+                .isEqualTo(1);
+    }
+
+    @Test
+    void JPQL_전화번호_검색_쿼리_실행_확인() {
+        // given
+        statistics.clear();
+
+        // when: JPQL 방식
+        List<User> result = findAllByPhoneNumberWithProfileJpql(
+                Gender.FEMALE,
+                "010-2000",
+                testUser.getId(),
+                TeamType.TWO_TO_TWO,
+                Event.NEUL_2025
+        );
+
+        // then
+        assertThat(result).hasSize(40);
+        assertThat(statistics.getQueryExecutionCount())
+                .as("JPQL NOT EXISTS 방식 쿼리 실행")
+                .isGreaterThanOrEqualTo(1);
+    }
+
+    @Test
+    void JPQL과_QueryDSL_전화번호_검색_결과_동일성_검증() {
+        // when: JPQL 방식
+        List<User> jpqlResult = findAllByPhoneNumberWithProfileJpql(
+                Gender.FEMALE,
+                "010-2000",
+                testUser.getId(),
+                TeamType.TWO_TO_TWO,
+                Event.NEUL_2025
+        );
+
+        entityManager.clear();
+
+        // when: QueryDSL 방식
+        List<User> queryDslResult = userRepository.findAllByPhoneNumberWithProfile(
+                Gender.FEMALE,
+                "010-2000",
+                testUser.getId(),
+                TeamType.TWO_TO_TWO,
+                Event.NEUL_2025
+        );
+
+        // then
+        assertThat(jpqlResult)
+                .as("JPQL과 QueryDSL 전화번호 검색 결과가 동일")
+                .hasSameSizeAs(queryDslResult)
+                .extracting(User::getId)
+                .containsExactlyInAnyOrderElementsOf(
+                        queryDslResult.stream().map(User::getId).toList()
+                );
+    }
+
+    // 헬퍼 메서드
+    private User createUser(String studentNumber, String nickname, String phoneNumber, String name, Gender gender) {
+        User user = User.builder()
+                .studentNumber(studentNumber)
+                .password("encodedPassword")
+                .name(name)
+                .phoneNumber(phoneNumber)
+                .pushAgree(true)
+                .fcmSendTwoTwo(false)
+                .build();
+        user = userRepository.save(user);
+        user.setIsDeleted(false); // Builder에 없으므로 setter 사용
+
+        UserProfile userProfile = UserProfile.builder()
+                .nickname(nickname)
+                .emoji("😀")
+                .music(Music.HIPHOP)
+                .mbti(MBTI.ENFP)
+                .style(Style.CUTIE)
+                .idealType(IdealType.CAT)
+                .idealAge(IdealAge.SAME)
+                .gender(gender)
+                .grade(Grade.FIRST)
+                .major(Major.CSIE)
+                .age(20)
+                .level(Level.LIGHT)
+                .user(user)
+                .build();
+        userProfileRepository.save(userProfile);
+
+        return user;
+    }
+
+    private Team createTeam(TeamType teamType, Event event) {
+        Team team = Team.builder()
+                .name("테스트팀")
+                .teamType(teamType)
+                .gender(Gender.FEMALE)
+                .activeStatus(ActiveStatus.ACTIVE)
+                .event(event)
+                .build();
+        return teamRepository.save(team);
+    }
+
+    private void createUserTeam(User user, Team team) {
+        UserTeam userTeam = UserTeam.builder()
+                .user(user)
+                .team(team)
+                .build();
+        userTeamRepository.save(userTeam);
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -15,6 +15,11 @@ spring:
     show-sql: true
     database-platform: org.hibernate.dialect.H2Dialect
 
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
   autoconfigure:
     exclude:
       - org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration


### PR DESCRIPTION
## 🎋 작업중인 브랜치 및 이슈

- #32 


## 🔑 주요 변경사항

### [기존 쿼리의 문제점] 
- 조건이 하나만 다른데 5개의 인자와 4줄의 쿼리로 메서드 분리, 과도한 서브 쿼리 및 JOIN
- 별도의 INDEX가 존재하지 않았고, LIKE 패턴 사용으로 테이블 FULL SCAN 발생
- JOIN 시 user_profile 쪽에 user_id 인덱스가 없으면 ⇒ UserProfile 테이블 FULL SCAN 발생
- 서브 쿼리 내부도 INDEX가 없다면 테이블 FULL SCAN 발생
- 해당 쿼리 메서드는 미팅 쪽 로직에서 자주 호출되고 있음


### [추가한 인덱스]
```
CREATE INDEX idx_userprofile_userid ON user_profile(user_id);
CREATE INDEX idx_userProfile_gender_nickname_userId ON user_profile(gender, nickname, user_id);
```

### [JPQL → QueryDSL 전환 목적]
- 서브쿼리 제거 + 쿼리 실행 횟수 감소(row 단위 반복 실행->1회) + 인덱스 활용 극대화 + N+1 제거 
- NOT EXISTS 서브쿼리 => LEFT JOIN + IS NULL 


### [테스트 검증]
<img width="484" height="116" alt="image" src="https://github.com/user-attachments/assets/414f0405-ade7-4a4d-9e5f-6d5b3b9d797c" />

아래 3가지를 기준으로 통합 테스트 진행
1. 기존 JPQL과 결과가 동일한지
2. 쿼리 실행 횟수(N+1 포함)가 줄었는지
3. 인덱스 기반 성능 최적화가 실제 반영되었는지



## Check List
- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - 사용자 검색(닉네임/전화번호) 조회 경로를 최적화해 쿼리 수를 줄이고 응답 속도를 개선했습니다.
  - 저장소 구조를 정리하여 확장성과 유지보수성을 높였습니다.
- Tests
  - 최적화된 조회가 단일 쿼리로 동작하고 결과가 일관적인지 검증하는 통합 테스트를 추가했습니다.
- Chores
  - 테스트 환경에 Redis 설정을 추가했습니다.
  - 사용자 정보 관련 세터를 보강해 향후 확장에 대비했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->