### PR TITLE
[FIX] 채팅 worker 서버 비활성화

### DIFF
--- a/src/main/java/com/gdg/z_meet/domain/chat/redis/RedisSubscriber.java
+++ b/src/main/java/com/gdg/z_meet/domain/chat/redis/RedisSubscriber.java
@@ -2,11 +2,11 @@ package com.gdg.z_meet.domain.chat.redis;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.gdg.z_meet.domain.chat.dto.ChatMessageCacheDto;
-import com.gdg.z_meet.domain.chat.dto.ChatMessageReq;
-import com.gdg.z_meet.domain.chat.dto.ChatMessageRes;
 import com.gdg.z_meet.domain.chat.service.ChatMessageHandlerService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Profile;
 import org.springframework.data.redis.connection.Message;
 import org.springframework.data.redis.connection.MessageListener;
 import org.springframework.messaging.simp.SimpMessageSendingOperations;
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Component;
 
 import java.nio.charset.StandardCharsets;
 
+@Profile("!worker")
 @Slf4j
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/com/gdg/z_meet/global/config/RedisConfig.java
+++ b/src/main/java/com/gdg/z_meet/global/config/RedisConfig.java
@@ -12,6 +12,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -105,6 +106,7 @@ public class RedisConfig {
 
     //메시지 받을때 실행될 리스너 어댑터(subscriber의 onMessage 메서드 실행)
     @Bean
+    @Profile("!worker")
     public MessageListenerAdapter listenerAdapter(RedisSubscriber subscriber) {
         // RedisSubscriber.onMessage() 실행되도록 연결
         return new MessageListenerAdapter(subscriber, "onMessage");


### PR DESCRIPTION
## 🎋 작업중인 브랜치 및 이슈

- 

## 🔑 주요 변경사항

- 채팅 전송 시 api 서버와 worker 서버 양측에서 모두 처리되어 분리
- api 서버에서만 redisSubscriber 활성화 하여 메시지 처리  



## Check List
- [ ] **Assignees** 등록을 하였나요?
- [ ] **라벨(Label)** 등록을 하였나요?
- [ ] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 사용자 기능 변화 없음.
- 리팩터
  - 프로필 기반 조건을 적용해 구성 애노테이션을 정비하고 초기화 경로를 단순화.
  - 불필요한 의존성(임포트) 정리.
- 작업(Chores)
  - 워커 프로필에서 메시지 리스너/구독 컴포넌트 로딩을 제외하여 배포 프로필별 역할을 명확화.
  - 실행 환경 분리로 불필요한 백그라운드 동작을 방지.
- 버그 수정
  - 특정 환경에서의 중복 구독 가능성을 줄여 안정성과 자원 효율을 개선.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->