### PR TITLE
[REFACTOR] 채팅 worker 서버 비활성화 위한 redis 재설정

### DIFF
--- a/src/main/java/com/gdg/z_meet/global/config/RedisConfig.java
+++ b/src/main/java/com/gdg/z_meet/global/config/RedisConfig.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.fasterxml.jackson.datatype.hibernate5.jakarta.Hibernate5JakartaModule;
 import com.gdg.z_meet.domain.chat.redis.RedisSubscriber;
+import com.gdg.z_meet.domain.meeting.MatchingMessageSubscriber;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -104,6 +105,13 @@ public class RedisConfig {
         return objectMapper;
     }
 
+    //매칭 리스너 어댑터
+    @Bean
+    @Profile("!worker") // 매칭 기능도 worker가 아니라면 여기에 Profile 추가
+    public MessageListenerAdapter matchingListenerAdapter(MatchingMessageSubscriber subscriber) {
+        return new MessageListenerAdapter(subscriber, "handleMessage");
+    }
+
     //메시지 받을때 실행될 리스너 어댑터(subscriber의 onMessage 메서드 실행)
     @Bean
     @Profile("!worker")
@@ -114,15 +122,19 @@ public class RedisConfig {
 
     //Redis Pub/Sub 구독을 관리하는 컨테이너
     @Bean
+    @Profile("!worker")
     public RedisMessageListenerContainer redisMessageListenerContainer(
             RedisConnectionFactory connectionFactory,
-            MessageListenerAdapter listenerAdapter) {
-
+            // @Qualifier를 사용해 어떤 리스너를 주입받을지 명시
+            @Qualifier("listenerAdapter") MessageListenerAdapter chatListenerAdapter,
+            @Qualifier("matchingListenerAdapter") MessageListenerAdapter matchingListenerAdapter
+    ) {
         RedisMessageListenerContainer container = new RedisMessageListenerContainer();
         container.setConnectionFactory(connectionFactory);
 
-        // 특정 채널 또는 패턴을 구독
-        container.addMessageListener(listenerAdapter, new PatternTopic("chat:room:*"));
+        // 필요한 모든 리스너를 이 컨테이너 하나에 등록
+        container.addMessageListener(chatListenerAdapter, new PatternTopic("chat:room:*"));
+        container.addMessageListener(matchingListenerAdapter, new PatternTopic("matching.*"));
 
         return container;
     }

--- a/src/main/java/com/gdg/z_meet/global/config/RedisMatchingConfig.java
+++ b/src/main/java/com/gdg/z_meet/global/config/RedisMatchingConfig.java
@@ -1,36 +1,36 @@
-package com.gdg.z_meet.global.config;
-
-import com.gdg.z_meet.domain.meeting.MatchingMessageSubscriber;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.data.redis.connection.RedisConnectionFactory;
-import org.springframework.data.redis.listener.PatternTopic;
-import org.springframework.data.redis.listener.RedisMessageListenerContainer;
-import org.springframework.data.redis.listener.adapter.MessageListenerAdapter;
-
-@Configuration
-public class RedisMatchingConfig {
-
-    @Bean
-    public PatternTopic matchingTopic() {
-
-        return new PatternTopic("matching.*");
-    }
-
-    @Bean
-    public MessageListenerAdapter matchingMessageListener(MatchingMessageSubscriber subscriber) {
-
-        return new MessageListenerAdapter(subscriber, "handleMessage");
-    }
-
-    @Bean
-    public RedisMessageListenerContainer matchingMessageContainer(RedisConnectionFactory connectionFactory,
-                                                                  MessageListenerAdapter matchingMessageListener,
-                                                                  PatternTopic matchingTopic) {
-
-        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
-        container.setConnectionFactory(connectionFactory);
-        container.addMessageListener(matchingMessageListener, matchingTopic);
-        return container;
-    }
-}
+//package com.gdg.z_meet.global.config;
+//
+//import com.gdg.z_meet.domain.meeting.MatchingMessageSubscriber;
+//import org.springframework.context.annotation.Bean;
+//import org.springframework.context.annotation.Configuration;
+//import org.springframework.data.redis.connection.RedisConnectionFactory;
+//import org.springframework.data.redis.listener.PatternTopic;
+//import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+//import org.springframework.data.redis.listener.adapter.MessageListenerAdapter;
+//
+//@Configuration
+//public class RedisMatchingConfig {
+//
+//    @Bean
+//    public PatternTopic matchingTopic() {
+//
+//        return new PatternTopic("matching.*");
+//    }
+//
+//    @Bean
+//    public MessageListenerAdapter matchingMessageListener(MatchingMessageSubscriber subscriber) {
+//
+//        return new MessageListenerAdapter(subscriber, "handleMessage");
+//    }
+//
+//    @Bean
+//    public RedisMessageListenerContainer matchingMessageContainer(RedisConnectionFactory connectionFactory,
+//                                                                  MessageListenerAdapter matchingMessageListener,
+//                                                                  PatternTopic matchingTopic) {
+//
+//        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+//        container.setConnectionFactory(connectionFactory);
+//        container.addMessageListener(matchingMessageListener, matchingTopic);
+//        return container;
+//    }
+//}


### PR DESCRIPTION
## 🎋 작업중인 브랜치 및 이슈

- #37 


## 🔑 주요 변경사항

- RedisMessageListenerContainer가 
Config와 MatchingConfig에서 중복으로 등록되고 있어 재설정
- listenerAdapter 빈 등록 재설정
- RedisMessageListenerContainer 리스너 등록 추가

-> worker 서버 채팅 처리 비활성화시켜 아키텍처 설계 목적에 맞게 알림 비동기 처리만 담당 

## Check List
- [ ] **Assignees** 등록을 하였나요?
- [ ] **라벨(Label)** 등록을 하였나요?
- [ ] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

• 신기능
  • 실시간 매칭 알림/업데이트가 앱 내에서 동시에 지원되어, 채팅과 매칭 이벤트를 함께 수신합니다.

• 버그 수정
  • 간헐적으로 누락되던 매칭 이벤트 수신 이슈를 개선해 알림 신뢰성을 높였습니다.

• 성능 개선
  • 이벤트 리스너 병렬 처리로 실시간 응답성과 안정성을 향상했습니다.

• 리팩터링
  • 분산되어 있던 실시간 처리 구성을 통합해 관리성을 개선하고 중복을 제거했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->