### PR TITLE
[REFACTOR] FCM Token Race Condition 관련 추가 개선

### DIFF
--- a/src/main/java/com/gdg/z_meet/domain/fcm/entity/FcmToken.java
+++ b/src/main/java/com/gdg/z_meet/domain/fcm/entity/FcmToken.java
@@ -8,6 +8,11 @@ import lombok.*;
 @Getter
 @Builder
 @Entity
+@Table(name = "fcm_token", 
+       uniqueConstraints = {
+           @UniqueConstraint(name = "uk_fcm_token_user", columnNames = "user_id"),
+           @UniqueConstraint(name = "uk_fcm_token_value", columnNames = "token")
+       })
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class FcmToken extends BaseEntity {

--- a/src/main/java/com/gdg/z_meet/domain/fcm/service/token/FcmTokenServiceImpl.java
+++ b/src/main/java/com/gdg/z_meet/domain/fcm/service/token/FcmTokenServiceImpl.java
@@ -13,7 +13,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 
 @Service
 @RequiredArgsConstructor
@@ -22,6 +24,9 @@ public class FcmTokenServiceImpl implements FcmTokenService {
 
     private final UserRepository userRepository;
     private final FcmTokenRepository fcmTokenRepository;
+    
+    // 사용자별 동기화를 위한 락 맵
+    private final Map<Long, Object> userLocks = new ConcurrentHashMap<>();
 
     /**
      *  FCM 푸시 알림 사용자 동의 여부
@@ -40,13 +45,32 @@ public class FcmTokenServiceImpl implements FcmTokenService {
      * FCM 토큰 동기화 (동시성 안전)
      * 
      * 동시성 문제 해결 전략:
-     * 1. 사용자 검증 후 단일 트랜잭션에서 처리
-     * 2. findByUserForUpdate로 락 획득하여 토큰 처리
-     * 3. 락이 걸린 상태에서 안전하게 업데이트/생성
+     * 1. 사용자별 동기화 락으로 동시성 보장
+     * 2. 사용자 검증 후 단일 트랜잭션에서 처리
+     * 3. findByUserForUpdate로 락 획득하여 토큰 처리
+     * 4. 락이 걸린 상태에서 안전하게 업데이트/생성
      */
     @Override
     @Transactional
     public void syncFcmToken(Long userId, UserReq.saveFcmTokenReq req) {
+        // 사용자별 동기화 락 획득
+        Object userLock = userLocks.computeIfAbsent(userId, k -> new Object());
+        
+        synchronized (userLock) {
+            try {
+                doSyncFcmToken(userId, req);
+            } finally {
+                // 메모리 누수 방지를 위해 락 제거
+                userLocks.remove(userId);
+            }
+        }
+    }
+    
+    /**
+     * 실제 FCM 토큰 동기화 로직
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    protected void doSyncFcmToken(Long userId, UserReq.saveFcmTokenReq req) {
         // 사용자 검증
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(Code.USER_NOT_FOUND));

--- a/src/main/java/com/gdg/z_meet/domain/fcm/service/token/FcmTokenServiceImpl.java
+++ b/src/main/java/com/gdg/z_meet/domain/fcm/service/token/FcmTokenServiceImpl.java
@@ -16,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantLock;
 
 @Service
 @RequiredArgsConstructor
@@ -26,7 +27,7 @@ public class FcmTokenServiceImpl implements FcmTokenService {
     private final FcmTokenRepository fcmTokenRepository;
     
     // 사용자별 동기화를 위한 락 맵
-    private final Map<Long, Object> userLocks = new ConcurrentHashMap<>();
+    private final Map<Long, ReentrantLock> userLocks = new ConcurrentHashMap<>();
 
     /**
      *  FCM 푸시 알림 사용자 동의 여부
@@ -54,14 +55,17 @@ public class FcmTokenServiceImpl implements FcmTokenService {
     @Transactional
     public void syncFcmToken(Long userId, UserReq.saveFcmTokenReq req) {
         // 사용자별 동기화 락 획득
-        Object userLock = userLocks.computeIfAbsent(userId, k -> new Object());
-        
-        synchronized (userLock) {
-            try {
-                doSyncFcmToken(userId, req);
-            } finally {
-                // 메모리 누수 방지를 위해 락 제거
-                userLocks.remove(userId);
+        ReentrantLock lock = userLocks.computeIfAbsent(userId, k -> new ReentrantLock());
+        lock.lock();
+
+        try {
+            doSyncFcmToken(userId, req);
+        } finally {
+            lock.unlock();
+
+            // 필요 시 조건부 제거(경합이 없을 때만)
+            if(!lock.isLocked() && !lock.hasQueuedThreads()){
+                userLocks.remove(userId, lock);
             }
         }
     }

--- a/src/main/java/com/gdg/z_meet/domain/fcm/service/token/FcmTokenServiceImpl.java
+++ b/src/main/java/com/gdg/z_meet/domain/fcm/service/token/FcmTokenServiceImpl.java
@@ -10,6 +10,7 @@ import com.gdg.z_meet.global.response.Code;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
@@ -36,11 +37,17 @@ public class FcmTokenServiceImpl implements FcmTokenService {
     }
 
     /**
-     *  FCM 토큰 갱신
+     * FCM 토큰 동기화 (동시성 안전)
+     * 
+     * 동시성 문제 해결 전략:
+     * 1. 사용자 검증 후 단일 트랜잭션에서 처리
+     * 2. findByUserForUpdate로 락 획득하여 토큰 처리
+     * 3. 락이 걸린 상태에서 안전하게 업데이트/생성
      */
     @Override
     @Transactional
     public void syncFcmToken(Long userId, UserReq.saveFcmTokenReq req) {
+        // 사용자 검증
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(Code.USER_NOT_FOUND));
 
@@ -50,15 +57,17 @@ public class FcmTokenServiceImpl implements FcmTokenService {
 
         String newToken = req.getFcmToken();
 
-        // 기존 토큰 row 조회 시점에 쓰기 락(동일 트랜잭션 읽기, 수정 방지)
+        // 기존 토큰 조회 및 락 획득
         Optional<FcmToken> existingOpt = fcmTokenRepository.findByUserForUpdate(user);
 
         if (existingOpt.isPresent()) {
             FcmToken existing = existingOpt.get();
             // 토큰이 다르면 업데이트
             if (!existing.getToken().equals(newToken)) {
-                existing.setToken(newToken);
-                fcmTokenRepository.flush();
+                existing.updateToken(newToken);
+                log.debug("FCM 토큰 업데이트 완료: userId={}", user.getId());
+            } else {
+                log.debug("FCM 토큰 동일, 업데이트 생략: userId={}", user.getId());
             }
         } else {
             // 없으면 새로 생성
@@ -68,6 +77,7 @@ public class FcmTokenServiceImpl implements FcmTokenService {
                             .token(newToken)
                             .build()
             );
+            log.debug("FCM 토큰 생성 완료: userId={}", user.getId());
         }
     }
 }

--- a/src/main/java/com/gdg/z_meet/global/response/Code.java
+++ b/src/main/java/com/gdg/z_meet/global/response/Code.java
@@ -96,7 +96,8 @@ public enum Code implements BaseCode {
 //    FEIGN_CLIENT_ERROR_500(HttpStatus.INTERNAL_SERVER_ERROR, "5001", "Inter server Error in feign client"),
     FCM_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "4002", "FCM 토큰을 찾을 수 없습니다."),
     FCM_PUSH_NOT_AGREED(HttpStatus.INTERNAL_SERVER_ERROR, "5002", "알림에 동의하지 않은 사용자입니다."),
-    FCM_SEND_MESSAGE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "5003", "FCM 서버에 메시지 전송 상황에서 에러 발생");
+    FCM_SEND_MESSAGE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "5003", "FCM 서버에 메시지 전송 상황에서 에러 발생"),
+    FCM_TOKEN_SYNC_FAILED(HttpStatus.CONFLICT, "5004", "FCM 토큰 동기화 중 충돌이 발생했습니다. 잠시 후 다시 시도해주세요.");
 
 //    NOT_ACADEMY_EMAIL("EEM-001", "Email is not a university email."),
 //    AUTH_CODE_NOT_MATCH("ATH-001", "Auth code not match."),

--- a/src/test/java/com/gdg/z_meet/domain/fcm/integration/fcm/FcmTokenConcurrencyTest.java
+++ b/src/test/java/com/gdg/z_meet/domain/fcm/integration/fcm/FcmTokenConcurrencyTest.java
@@ -69,119 +69,127 @@ class FcmTokenConcurrencyTest {
 
     @AfterEach
     void tearDown() {
+        // FCM 토큰 먼저 삭제 (외래키 제약조건 때문에)
         fcmTokenRepository.deleteAll();
+        // 사용자 삭제
         userRepository.deleteAll();
+        // 영속성 컨텍스트 비우기
+        em.clear();
     }
+
 
     @Test
     @Transactional(propagation = Propagation.NOT_SUPPORTED)
-    @DisplayName("동시에 여러 요청이 들어와도 FcmToken은 1개만 생성된다")
-    void 동시_요청시_토큰_중복_생성_방지() throws InterruptedException {
+    @DisplayName("CASE 1: 기존에 토큰이 있을 때 여러 요청이 동시에 update 시도")
+    void CASE1_기존_토큰_있음_동시_UPDATE_시도() throws InterruptedException {
+        // DB에 이미 user_id의 토큰 "old-token" 존재
+        String oldToken = "old-token";
+        FcmToken existingToken = FcmToken.builder()
+                .user(testUser)
+                .token(oldToken)
+                .build();
+        fcmTokenRepository.save(existingToken);
+
+        // 기존 토큰 존재 확인
+        List<FcmToken> beforeTokens = fcmTokenRepository.findAllByUser(testUser);
+        assertThat(beforeTokens).hasSize(1);
+        assertThat(beforeTokens.get(0).getToken()).isEqualTo(oldToken);
+
         int threadCount = 10;
         ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
         CountDownLatch latch = new CountDownLatch(threadCount);
         AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger failureCount = new AtomicInteger(0);
 
+        // 10개 스레드가 "updated-token-0" ~ "updated-token-9"로 동시에 요청
         for (int i = 0; i < threadCount; i++) {
-            final int index = i;
+            final int tokenIndex = i;
             executorService.submit(() -> {
                 try {
+                    String newToken = "updated-token-" + tokenIndex;
                     UserReq.saveFcmTokenReq req = UserReq.saveFcmTokenReq.builder()
-                            .fcmToken("concurrent-token-" + index)
+                            .fcmToken(newToken)
                             .build();
 
                     fcmTokenService.syncFcmToken(testUser.getId(), req);
                     successCount.incrementAndGet();
                 } catch (Exception e) {
-                    System.err.println("Thread " + index + " failed: " + e.getMessage());
+                    failureCount.incrementAndGet();
+                    System.err.println("Thread " + tokenIndex + " failed: " + e.getMessage());
                 } finally {
                     latch.countDown();
                 }
             });
         }
 
-        latch.await(10, TimeUnit.SECONDS);
+        latch.await(15, TimeUnit.SECONDS);
         executorService.shutdown();
 
-        // DB에서 다시 조회 (1개만 존재해야 함)
-        List<FcmToken> tokens = fcmTokenRepository.findAllByUser(testUser);
+        // 검증: DB에는 여전히 row 1개만 존재
+        List<FcmToken> afterTokens = fcmTokenRepository.findAllByUser(testUser);
 
-        assertThat(tokens).hasSize(1);
-    }
+        System.out.println("=== CASE 1 결과 ===");
+        System.out.println("성공한 요청: " + successCount.get());
+        System.out.println("실패한 요청: " + failureCount.get());
+        System.out.println("최종 토큰 개수: " + afterTokens.size());
+        System.out.println("최종 토큰 값: " + afterTokens.get(0).getToken());
 
-
-    @Test
-    @Transactional(propagation = Propagation.NOT_SUPPORTED)
-    @DisplayName("동시에 같은 토큰으로 요청해도 중복 생성되지 않는다")
-    void 동시_요청_같은_토큰_중복_방지() throws InterruptedException {
-        int threadCount = 5;
-        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
-        CountDownLatch latch = new CountDownLatch(threadCount);
-
-        String sameToken = "same-token-value";
-
-        for (int i = 0; i < threadCount; i++) {
-            executorService.submit(() -> {
-                try {
-                    UserReq.saveFcmTokenReq req = UserReq.saveFcmTokenReq.builder()
-                            .fcmToken(sameToken)
-                            .build();
-
-                    fcmTokenService.syncFcmToken(testUser.getId(), req);
-                } catch (Exception e) {
-                    System.err.println("Failed: " + e.getMessage());
-                } finally {
-                    latch.countDown();
-                }
-            });
-        }
-
-        latch.await(10, TimeUnit.SECONDS);
-        executorService.shutdown();
-
-        List<FcmToken> tokens = fcmTokenRepository.findAllByUser(testUser);
-
-        assertThat(tokens).hasSize(1);
-        assertThat(tokens.get(0).getToken()).isEqualTo(sameToken);
+        // 검증 포인트
+        assertThat(afterTokens).hasSize(1); // row 개수 유지 (COUNT(*) = 1)
+        assertThat(successCount.get()).isEqualTo(threadCount); // 예외/충돌 없이 모든 요청 정상 커밋
+        assertThat(failureCount.get()).isEqualTo(0); // Deadlock 없이 정상 종료
+        assertThat(afterTokens.get(0).getToken()).startsWith("updated-token-"); // 최종 token 값은 요청 중 하나의 값
     }
 
     @Test
     @Transactional(propagation = Propagation.NOT_SUPPORTED)
-    @DisplayName("기존 토큰이 있을 때 동시 업데이트 요청이 와도 1개만 유지된다")
-    void 기존_토큰_존재시_동시_업데이트_중복_방지() throws InterruptedException {
-        FcmToken existingToken = FcmToken.builder()
-                .user(testUser)
-                .token("existing-token")
-                .build();
-        fcmTokenRepository.save(existingToken);
+    @DisplayName("CASE 2: 기존에 토큰이 없는 상태에서 여러 요청이 동시에 insert 시도")
+    void CASE1_기존_토큰_없음_동시_INSERT_시도() throws InterruptedException {
+        // DB에 user_id의 FcmToken row가 없는 상태 확인
+        List<FcmToken> beforeTokens = fcmTokenRepository.findAllByUser(testUser);
+        assertThat(beforeTokens).isEmpty();
 
         int threadCount = 10;
         ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
         CountDownLatch latch = new CountDownLatch(threadCount);
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger failureCount = new AtomicInteger(0);
 
+        // 동시에 10개의 스레드가 서로 다른 토큰 값으로 요청
         for (int i = 0; i < threadCount; i++) {
-            final int index = i;
+            final int tokenIndex = i;
             executorService.submit(() -> {
                 try {
                     UserReq.saveFcmTokenReq req = UserReq.saveFcmTokenReq.builder()
-                            .fcmToken("updated-token-" + index)
+                            .fcmToken("token-" + tokenIndex)
                             .build();
 
                     fcmTokenService.syncFcmToken(testUser.getId(), req);
+                    successCount.incrementAndGet();
                 } catch (Exception e) {
-                    System.err.println("Thread " + index + " failed: " + e.getMessage());
+                    failureCount.incrementAndGet();
+                    System.err.println("Thread " + tokenIndex + " failed: " + e.getMessage());
                 } finally {
                     latch.countDown();
                 }
             });
         }
 
-        latch.await(10, TimeUnit.SECONDS);
+        latch.await(15, TimeUnit.SECONDS);
         executorService.shutdown();
 
-        List<FcmToken> tokens = fcmTokenRepository.findAllByUser(testUser);
+        // 검증: DB에는 최종적으로 1개의 row만 존재
+        List<FcmToken> afterTokens = fcmTokenRepository.findAllByUser(testUser);
 
-        assertThat(tokens).hasSize(1);
-        assertThat(tokens.get(0).getToken()).startsWith("updated-token-");
+        System.out.println("=== CASE 2 결과 ===");
+        System.out.println("성공한 요청: " + successCount.get());
+        System.out.println("실패한 요청: " + failureCount.get());
+        System.out.println("최종 토큰 개수: " + afterTokens.size());
+        System.out.println("최종 토큰 값: " + (afterTokens.isEmpty() ? "없음" : afterTokens.get(0).getToken()));
+
+        // 검증 포인트
+        assertThat(afterTokens).hasSize(1); // DB에는 1개의 row만 존재
+        assertThat(successCount.get()).isGreaterThan(0); // 최소 1개는 성공
+        // UNIQUE 에러는 발생할 수 있지만, 최종적으로 1개만 존재하면 OK
     }
 }

--- a/src/test/java/com/gdg/z_meet/domain/fcm/integration/fcm/FcmTokenLockManagementTest.java
+++ b/src/test/java/com/gdg/z_meet/domain/fcm/integration/fcm/FcmTokenLockManagementTest.java
@@ -1,0 +1,257 @@
+package com.gdg.z_meet.domain.fcm.integration.fcm;
+
+import com.gdg.z_meet.domain.fcm.entity.FcmToken;
+import com.gdg.z_meet.domain.fcm.repository.FcmTokenRepository;
+import com.gdg.z_meet.domain.fcm.service.token.FcmTokenService;
+import com.gdg.z_meet.domain.fcm.service.token.FcmTokenServiceImpl;
+import com.gdg.z_meet.domain.fcm.unit.config.QueryDslTestConfig;
+import com.gdg.z_meet.domain.user.dto.UserReq;
+import com.gdg.z_meet.domain.user.entity.User;
+import com.gdg.z_meet.domain.user.repository.UserRepository;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * ReentrantLock 도입이 분할 락(split lock) 문제를 해결했는지 검증
+ * 
+ * 검증 포인트:
+ * 1. Split Lock 해결: 동일 userId에 대해 동일 락 객체 사용 보장
+ * 2. 락 관리: 조건부 제거가 올바르게 동작하는지
+ * 3. 메모리 안전성: 락 객체가 적절히 정리되는지
+ * 4. 동시성 안전성: UNIQUE 제약조건 위반 없이 정상 동작
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
+@Import({FcmTokenServiceImpl.class, QueryDslTestConfig.class})
+@Rollback(value = false)
+@DisplayName("ReentrantLock 분할 락 해결 검증 테스트")
+class FcmTokenLockManagementTest {
+
+    @Autowired
+    private FcmTokenService fcmTokenService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private FcmTokenRepository fcmTokenRepository;
+
+    @Autowired
+    private EntityManager em;
+
+    private User testUser;
+
+    @BeforeEach
+    void setUp() {
+        testUser = User.builder()
+                .studentNumber("2024" + System.currentTimeMillis()) // 중복 방지
+                .name("락관리테스트")
+                .phoneNumber("010-" + System.currentTimeMillis())
+                .password("password")
+                .pushAgree(true)
+                .build();
+        testUser = userRepository.saveAndFlush(testUser);
+        em.clear();
+    }
+
+    @AfterEach
+    void tearDown() {
+        fcmTokenRepository.deleteAll();
+        userRepository.deleteAll();
+        em.clear();
+    }
+
+    /**
+     * 검증 1: 분할 락(split lock) 해결 확인
+     * 
+     * ReentrantLock 구현의 핵심:
+     * - 조건부 제거(hasQueuedThreads 체크)로 동일 락 객체 보장
+     * - synchronized(Object)는 finally에서 즉시 remove 시 다른 락 객체 발생 가능
+     * 
+     * 검증 방법: UNIQUE 제약조건 위반 없이 모든 요청이 성공하는지 확인
+     */
+    @Test
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    @DisplayName("검증 1: 분할 락 해결 - 동시 요청 시 UNIQUE 제약조건 위반 없음")
+    void 검증1_Synchronized_해결_UNIQUE제약조건위반없음() throws InterruptedException {
+        int threadCount = 20;
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger failureCount = new AtomicInteger(0);
+
+        // 동시에 요청
+        for (int i = 0; i < threadCount; i++) {
+            final int tokenIndex = i;
+            executorService.submit(() -> {
+                try {
+                    UserReq.saveFcmTokenReq req = UserReq.saveFcmTokenReq.builder()
+                            .fcmToken("split-lock-test-token-" + tokenIndex)
+                            .build();
+
+                    fcmTokenService.syncFcmToken(testUser.getId(), req);
+                    successCount.incrementAndGet();
+                } catch (Exception e) {
+                    failureCount.incrementAndGet();
+                    System.err.println("Thread " + tokenIndex + " failed: " + e.getMessage());
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await(15, TimeUnit.SECONDS);
+        executorService.shutdown();
+
+        // 검증: DB에는 1개만 존재 (분할 락 발생 시 여러 개 생성됨)
+        List<FcmToken> afterTokens = fcmTokenRepository.findAllByUser(testUser);
+
+        System.out.println("=== 검증 1: Synchronized 개선 ===");
+        System.out.println("성공: " + successCount.get() + ", 실패: " + failureCount.get());
+        System.out.println("최종 토큰 개수: " + afterTokens.size());
+
+        // 핵심 검증: 분할 락이 발생하지 않았는지
+        assertThat(afterTokens).hasSize(1); // 1개만 존재
+        assertThat(successCount.get()).isEqualTo(threadCount); // 모두 성공
+        assertThat(failureCount.get()).isEqualTo(0); // 실패 없음
+    }
+
+    /**
+     * 검증 2: 락 해제 및 관리 로직 확인
+     * 
+     * 조건부 제거 로직:
+     * if(!lock.isLocked() && !lock.hasQueuedThreads()) {
+     *     userLocks.remove(userId, lock);
+     * }
+     * 
+     * 검증 방법: 연속 요청 시 정상 동작하는지 확인
+     */
+    @Test
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    @DisplayName("검증 2: 락 관리 - 연속 요청 시 정상 동작")
+    void 검증2_락관리_연속요청_정상동작() throws InterruptedException {
+        // 첫 요청
+        UserReq.saveFcmTokenReq req1 = UserReq.saveFcmTokenReq.builder()
+                .fcmToken("test-token-1")
+                .build();
+        fcmTokenService.syncFcmToken(testUser.getId(), req1);
+        
+        // 첫 요청 후 상태 확인
+        List<FcmToken> tokensAfterFirst = fcmTokenRepository.findAllByUser(testUser);
+        assertThat(tokensAfterFirst).hasSize(1);
+        
+        // 여러 요청 동시 실행
+        int threadCount = 10;
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+        AtomicInteger successCount = new AtomicInteger(0);
+
+        for (int i = 0; i < threadCount; i++) {
+            final int tokenIndex = i;
+            executorService.submit(() -> {
+                try {
+                    UserReq.saveFcmTokenReq req = UserReq.saveFcmTokenReq.builder()
+                            .fcmToken("test-token-" + tokenIndex)
+                            .build();
+                    fcmTokenService.syncFcmToken(testUser.getId(), req);
+                    successCount.incrementAndGet();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await(10, TimeUnit.SECONDS);
+        executorService.shutdown();
+
+        // 최종 검증: 정상 동작
+        List<FcmToken> tokens = fcmTokenRepository.findAllByUser(testUser);
+        System.out.println("=== 검증 2: 락 관리 ===");
+        System.out.println("성공: " + successCount.get());
+        System.out.println("최종 토큰 개수: " + tokens.size());
+        
+        assertThat(tokens).hasSize(1); // 1개만 존재
+        assertThat(successCount.get()).isEqualTo(threadCount); // 모두 성공
+    }
+
+    /**
+     * 검증 4: 여러 사용자 동시 요청 - 각 사용자별로 분리된 락 사용
+     * 
+     * 검증 포인트:
+     * - 여러 사용자가 동시에 요청해도 각자의 락 사용
+     * - 사용자 간 간섭 없음
+     */
+    @Test
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    @DisplayName("검증 4: 여러 사용자 동시 요청 - 사용자별 분리된 락")
+    void 검증4_여러사용자_동시요청_분리된락() throws InterruptedException {
+        // 여러 사용자 생성
+        User[] users = new User[5];
+        for (int i = 0; i < 5; i++) {
+            users[i] = User.builder()
+                    .studentNumber("202500" + i)
+                    .name("멀티사용자" + i)
+                    .phoneNumber("010-2222-000" + i)
+                    .password("password")
+                    .pushAgree(true)
+                    .build();
+            userRepository.saveAndFlush(users[i]);
+        }
+
+        int threadCountPerUser = 10;
+        ExecutorService executorService = Executors.newFixedThreadPool(50);
+        CountDownLatch latch = new CountDownLatch(users.length * threadCountPerUser);
+        AtomicInteger successCount = new AtomicInteger(0);
+
+        for (User user : users) {
+            for (int i = 0; i < threadCountPerUser; i++) {
+                final int tokenIndex = i;
+                executorService.submit(() -> {
+                    try {
+                        UserReq.saveFcmTokenReq req = UserReq.saveFcmTokenReq.builder()
+                                .fcmToken("multi-user-token-" + user.getId() + "-" + tokenIndex)
+                                .build();
+                        fcmTokenService.syncFcmToken(user.getId(), req);
+                        successCount.incrementAndGet();
+                    } finally {
+                        latch.countDown();
+                    }
+                });
+            }
+        }
+
+        latch.await(20, TimeUnit.SECONDS);
+        executorService.shutdown();
+
+        System.out.println("=== 검증 4: 여러 사용자 동시 요청 ===");
+        System.out.println("성공 요청 수: " + successCount.get());
+
+        // 각 사용자별로 1개의 토큰만 존재해야 함
+        for (User user : users) {
+            List<FcmToken> tokens = fcmTokenRepository.findAllByUser(user);
+            assertThat(tokens).hasSize(1);
+        }
+    }
+}
+

--- a/src/test/java/com/gdg/z_meet/domain/fcm/unit/service/token/FcmTokenServiceImplTest.java
+++ b/src/test/java/com/gdg/z_meet/domain/fcm/unit/service/token/FcmTokenServiceImplTest.java
@@ -142,7 +142,6 @@ class FcmTokenServiceImplTest {
 
         verify(userRepository).findById(1L);
         verify(fcmTokenRepository).findByUserForUpdate(testUser);
-        verify(fcmTokenRepository).flush();
         assertEquals("updated-fcm-token", existingToken.getToken());
     }
 
@@ -204,7 +203,7 @@ class FcmTokenServiceImplTest {
 
         fcmTokenService.syncFcmToken(1L, req);
 
-        verify(fcmTokenRepository).flush();
+        verify(fcmTokenRepository).findByUserForUpdate(testUser);
         assertEquals("new-token-after-update", existingToken.getToken());
     }
 }


### PR DESCRIPTION
## 🎋 작업중인 브랜치 및 이슈

- #40 


## 🎯 변경 이유

- 통합 테스트 케이스 2번(기존에 토큰이 없는 상태에서 여러 요청이 동시에 insert 시도)에서 `Unique index or primary key violation` 발생
- 조회 시점에 PESSIMISTIC_WRITE(쓰기 락)을 적용하였지만, 이는 ROW가 없을 경우(토큰 X)에 대해 락이 걸리지 않음을 확인


## 🔑 주요 변경사항

### 1. JVM 내 동기화 메커니즘 추가
- ConcurrentHashMap을 통해 userId에 대한 ReentrantLock 객체를 관리하여, 동일한 유저에 대한 요청이 동시에 들어와도, 같은 lock 객체를 참조하도록 함.
- ReentrantLock.lock()을 통해 동일 userId에 대한 요청을 순차적으로 직렬화
- 조건부 제거(!lock.isLocked() && !lock.hasQueuedThreads()) 로 메모리 누수와 분할 락(split lock) 동시에 방지

findByUserForUpdate()는 DB row 존재 시 DB 락으로 정합성을 보장,
ReentrantLock은 row 부재 시 애플리케이션 레벨 락으로 동시 insert 차단
→ 두 계층의 이중 방어(Double Locking) 로 race condition 완전 방지


### 2. 트랜잭션 전파 수준 개선
- syncFcmToken()은 요청 단위로 묶고, 내부의 doSyncFcmToken()에는 @Transactional(propagation = Propagation.REQUIRES_NEW)를 적용
-  트랜잭션 경계를 명확히 분리하고, 각 사용자 요청 단위로 독립적인 커밋·롤백이 가능하도록 개선
- 락 보유 시간 최소화 및 교착(deadlock) 위험 완화

### 3. 통합 테스트 플로우 구체화
- 멀티스레드 환경에서 동시에 같은 userId로 요청을 발생시키는 시나리오 구성
Case 1: 기존 토큰이 없는 상태에서 다중 insert 시도 → 중복 row 방지 검증
Case 2: 기존 토큰이 있는 상태에서 다중 update 시도 → 순차 update 검증
- 테스트 종료 후 SELECT COUNT(*) = 1 및 token 값 일관성 확인으로 동시성 제어 및 정합성 확보 여부를 최종 검증


<br> 

https://www.nextblog.me/parkmineum/280303e2-5222-80ac-83e4-ea3a55fea074
https://www.nextblog.me/parkmineum/298303e2-5222-801e-82f7-dfabbadbfcd0


## Check List
- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 사용자별 FCM 토큰 동기화에 사용자 단위 잠금(분리된 락)을 도입해 동시성 안정성을 강화했습니다.
  * 데이터베이스 레벨에서 사용자·토큰 중복을 방지하는 유니크 제약을 추가했습니다.

* **버그 수정**
  * 동기화 충돌 상황에 대해 명확한 충돌 응답 코드를 도입해 실패를 명확히 처리합니다.

* **테스트**
  * 동시성 시나리오를 확장한 통합 및 락 관리 테스트를 추가·보강했습니다.
  * 단위 테스트의 검증 흐름을 동시성 맞춤으로 수정했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->