### PR TITLE
[REFACTOR] REQUIRES_NEW 트랜잭션 독립 실행 보장

### DIFF
--- a/src/main/java/com/gdg/z_meet/domain/fcm/service/token/FcmTokenServiceImpl.java
+++ b/src/main/java/com/gdg/z_meet/domain/fcm/service/token/FcmTokenServiceImpl.java
@@ -1,7 +1,5 @@
 package com.gdg.z_meet.domain.fcm.service.token;
 
-import com.gdg.z_meet.domain.fcm.entity.FcmToken;
-import com.gdg.z_meet.domain.fcm.repository.FcmTokenRepository;
 import com.gdg.z_meet.domain.user.dto.UserReq;
 import com.gdg.z_meet.domain.user.entity.User;
 import com.gdg.z_meet.domain.user.repository.UserRepository;
@@ -10,11 +8,9 @@ import com.gdg.z_meet.global.response.Code;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -24,7 +20,7 @@ import java.util.concurrent.locks.ReentrantLock;
 public class FcmTokenServiceImpl implements FcmTokenService {
 
     private final UserRepository userRepository;
-    private final FcmTokenRepository fcmTokenRepository;
+    private final FcmTokenTransactionService fcmTokenTransactionService;
     
     // 사용자별 동기화를 위한 락 맵
     private final Map<Long, ReentrantLock> userLocks = new ConcurrentHashMap<>();
@@ -47,19 +43,19 @@ public class FcmTokenServiceImpl implements FcmTokenService {
      * 
      * 동시성 문제 해결 전략:
      * 1. 사용자별 동기화 락으로 동시성 보장
-     * 2. 사용자 검증 후 단일 트랜잭션에서 처리
-     * 3. findByUserForUpdate로 락 획득하여 토큰 처리
-     * 4. 락이 걸린 상태에서 안전하게 업데이트/생성
+     * 2. 외부 트랜잭션에서 락 관리
+     * 3. REQUIRES_NEW로 독립 트랜잭션에서 DB 작업 수행
+     * 4. findByUserForUpdate로 락 획득하여 토큰 처리
+     * 5. 락이 걸린 상태에서 안전하게 업데이트/생성
      */
     @Override
-    @Transactional
     public void syncFcmToken(Long userId, UserReq.saveFcmTokenReq req) {
         // 사용자별 동기화 락 획득
         ReentrantLock lock = userLocks.computeIfAbsent(userId, k -> new ReentrantLock());
         lock.lock();
 
         try {
-            doSyncFcmToken(userId, req);
+            fcmTokenTransactionService.doSyncFcmToken(userId, req);
         } finally {
             lock.unlock();
 
@@ -67,45 +63,6 @@ public class FcmTokenServiceImpl implements FcmTokenService {
             if(!lock.isLocked() && !lock.hasQueuedThreads()){
                 userLocks.remove(userId, lock);
             }
-        }
-    }
-    
-    /**
-     * 실제 FCM 토큰 동기화 로직
-     */
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
-    protected void doSyncFcmToken(Long userId, UserReq.saveFcmTokenReq req) {
-        // 사용자 검증
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new BusinessException(Code.USER_NOT_FOUND));
-
-        if (!user.isPushAgree()) {
-            throw new BusinessException(Code.FCM_PUSH_NOT_AGREED);
-        }
-
-        String newToken = req.getFcmToken();
-
-        // 기존 토큰 조회 및 락 획득
-        Optional<FcmToken> existingOpt = fcmTokenRepository.findByUserForUpdate(user);
-
-        if (existingOpt.isPresent()) {
-            FcmToken existing = existingOpt.get();
-            // 토큰이 다르면 업데이트
-            if (!existing.getToken().equals(newToken)) {
-                existing.updateToken(newToken);
-                log.debug("FCM 토큰 업데이트 완료: userId={}", user.getId());
-            } else {
-                log.debug("FCM 토큰 동일, 업데이트 생략: userId={}", user.getId());
-            }
-        } else {
-            // 없으면 새로 생성
-            fcmTokenRepository.save(
-                    FcmToken.builder()
-                            .user(user)
-                            .token(newToken)
-                            .build()
-            );
-            log.debug("FCM 토큰 생성 완료: userId={}", user.getId());
         }
     }
 }

--- a/src/main/java/com/gdg/z_meet/domain/fcm/service/token/FcmTokenTransactionService.java
+++ b/src/main/java/com/gdg/z_meet/domain/fcm/service/token/FcmTokenTransactionService.java
@@ -1,0 +1,74 @@
+package com.gdg.z_meet.domain.fcm.service.token;
+
+import com.gdg.z_meet.domain.fcm.entity.FcmToken;
+import com.gdg.z_meet.domain.fcm.repository.FcmTokenRepository;
+import com.gdg.z_meet.domain.user.dto.UserReq;
+import com.gdg.z_meet.domain.user.entity.User;
+import com.gdg.z_meet.domain.user.repository.UserRepository;
+import com.gdg.z_meet.global.exception.BusinessException;
+import com.gdg.z_meet.global.response.Code;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+/**
+ * FCM 토큰 동기화를 위한 트랜잭션 전용 서비스
+ * 
+ * REQUIRES_NEW 전파 전략을 별도 빈으로 분리하여
+ * 외부 트랜잭션과 독립적으로 동작하도록 함
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class FcmTokenTransactionService {
+
+    private final UserRepository userRepository;
+    private final FcmTokenRepository fcmTokenRepository;
+
+    /**
+     * 실제 FCM 토큰 동기화 로직 (REQUIRES_NEW 전파 전략)
+     * 
+     * 외부 트랜잭션과 독립적으로 새로운 트랜잭션을 시작하여
+     * 동시성 문제를 해결함
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void doSyncFcmToken(Long userId, UserReq.saveFcmTokenReq req) {
+        // 사용자 검증
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(Code.USER_NOT_FOUND));
+
+        if (!user.isPushAgree()) {
+            throw new BusinessException(Code.FCM_PUSH_NOT_AGREED);
+        }
+
+        String newToken = req.getFcmToken();
+
+        // 기존 토큰 조회 및 락 획득
+        Optional<FcmToken> existingOpt = fcmTokenRepository.findByUserForUpdate(user);
+
+        if (existingOpt.isPresent()) {
+            FcmToken existing = existingOpt.get();
+            // 토큰이 다르면 업데이트
+            if (!existing.getToken().equals(newToken)) {
+                existing.updateToken(newToken);
+                log.debug("FCM 토큰 업데이트 완료: userId={}", user.getId());
+            } else {
+                log.debug("FCM 토큰 동일, 업데이트 생략: userId={}", user.getId());
+            }
+        } else {
+            // 없으면 새로 생성
+            fcmTokenRepository.save(
+                    FcmToken.builder()
+                            .user(user)
+                            .token(newToken)
+                            .build()
+            );
+            log.debug("FCM 토큰 생성 완료: userId={}", user.getId());
+        }
+    }
+}
+

--- a/src/test/java/com/gdg/z_meet/domain/fcm/integration/fcm/FcmTokenConcurrencyTest.java
+++ b/src/test/java/com/gdg/z_meet/domain/fcm/integration/fcm/FcmTokenConcurrencyTest.java
@@ -4,6 +4,7 @@ import com.gdg.z_meet.domain.fcm.entity.FcmToken;
 import com.gdg.z_meet.domain.fcm.repository.FcmTokenRepository;
 import com.gdg.z_meet.domain.fcm.service.token.FcmTokenService;
 import com.gdg.z_meet.domain.fcm.service.token.FcmTokenServiceImpl;
+import com.gdg.z_meet.domain.fcm.service.token.FcmTokenTransactionService;
 import com.gdg.z_meet.domain.fcm.unit.config.QueryDslTestConfig;
 import com.gdg.z_meet.domain.user.dto.UserReq;
 import com.gdg.z_meet.domain.user.entity.User;
@@ -34,7 +35,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @ActiveProfiles("test")
-@Import({FcmTokenServiceImpl.class, QueryDslTestConfig.class})
+@Import({FcmTokenServiceImpl.class, FcmTokenTransactionService.class, QueryDslTestConfig.class})
 @Rollback(value = false)
 @DisplayName("FCM 토큰 동시성 통합 테스트")
 class FcmTokenConcurrencyTest {
@@ -55,6 +56,7 @@ class FcmTokenConcurrencyTest {
 
     @BeforeEach
     void setUp() {
+        
         testUser = User.builder()
                 .studentNumber("20192098")
                 .name("동시성테스트")
@@ -144,7 +146,7 @@ class FcmTokenConcurrencyTest {
     @Test
     @Transactional(propagation = Propagation.NOT_SUPPORTED)
     @DisplayName("CASE 2: 기존에 토큰이 없는 상태에서 여러 요청이 동시에 insert 시도")
-    void CASE1_기존_토큰_없음_동시_INSERT_시도() throws InterruptedException {
+    void CASE2_기존_토큰_없음_동시_INSERT_시도() throws InterruptedException {
         // DB에 user_id의 FcmToken row가 없는 상태 확인
         List<FcmToken> beforeTokens = fcmTokenRepository.findAllByUser(testUser);
         assertThat(beforeTokens).isEmpty();

--- a/src/test/java/com/gdg/z_meet/domain/fcm/integration/fcm/FcmTokenLockManagementTest.java
+++ b/src/test/java/com/gdg/z_meet/domain/fcm/integration/fcm/FcmTokenLockManagementTest.java
@@ -4,6 +4,7 @@ import com.gdg.z_meet.domain.fcm.entity.FcmToken;
 import com.gdg.z_meet.domain.fcm.repository.FcmTokenRepository;
 import com.gdg.z_meet.domain.fcm.service.token.FcmTokenService;
 import com.gdg.z_meet.domain.fcm.service.token.FcmTokenServiceImpl;
+import com.gdg.z_meet.domain.fcm.service.token.FcmTokenTransactionService;
 import com.gdg.z_meet.domain.fcm.unit.config.QueryDslTestConfig;
 import com.gdg.z_meet.domain.user.dto.UserReq;
 import com.gdg.z_meet.domain.user.entity.User;
@@ -43,7 +44,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @ActiveProfiles("test")
-@Import({FcmTokenServiceImpl.class, QueryDslTestConfig.class})
+@Import({FcmTokenServiceImpl.class, FcmTokenTransactionService.class, QueryDslTestConfig.class})
 @Rollback(value = false)
 @DisplayName("ReentrantLock 분할 락 해결 검증 테스트")
 class FcmTokenLockManagementTest {

--- a/src/test/java/com/gdg/z_meet/domain/fcm/unit/service/token/FcmTokenServiceImplTest.java
+++ b/src/test/java/com/gdg/z_meet/domain/fcm/unit/service/token/FcmTokenServiceImplTest.java
@@ -31,6 +31,9 @@ class FcmTokenServiceImplTest {
 
     @Mock
     private FcmTokenRepository fcmTokenRepository;
+    
+    @Mock
+    private com.gdg.z_meet.domain.fcm.service.token.FcmTokenTransactionService fcmTokenTransactionService;
 
     @InjectMocks
     private FcmTokenServiceImpl fcmTokenService;
@@ -115,17 +118,11 @@ class FcmTokenServiceImplTest {
                 .fcmToken("new-fcm-token")
                 .build();
 
-        when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
-        when(fcmTokenRepository.findByUserForUpdate(testUser)).thenReturn(Optional.empty());
+        doNothing().when(fcmTokenTransactionService).doSyncFcmToken(1L, req);
 
         fcmTokenService.syncFcmToken(1L, req);
 
-        verify(userRepository).findById(1L);
-        verify(fcmTokenRepository).findByUserForUpdate(testUser);
-        verify(fcmTokenRepository).save(argThat(token ->
-                token.getToken().equals("new-fcm-token") &&
-                        token.getUser().equals(testUser)
-        ));
+        verify(fcmTokenTransactionService).doSyncFcmToken(1L, req);
     }
 
     @Test
@@ -135,14 +132,11 @@ class FcmTokenServiceImplTest {
                 .fcmToken("updated-fcm-token")
                 .build();
 
-        when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
-        when(fcmTokenRepository.findByUserForUpdate(testUser)).thenReturn(Optional.of(existingToken));
+        doNothing().when(fcmTokenTransactionService).doSyncFcmToken(1L, req);
 
         fcmTokenService.syncFcmToken(1L, req);
 
-        verify(userRepository).findById(1L);
-        verify(fcmTokenRepository).findByUserForUpdate(testUser);
-        assertEquals("updated-fcm-token", existingToken.getToken());
+        verify(fcmTokenTransactionService).doSyncFcmToken(1L, req);
     }
 
     @Test
@@ -151,7 +145,8 @@ class FcmTokenServiceImplTest {
                 .fcmToken("new-token")
                 .build();
 
-        when(userRepository.findById(1L)).thenReturn(Optional.empty());
+        doThrow(new BusinessException(Code.USER_NOT_FOUND))
+                .when(fcmTokenTransactionService).doSyncFcmToken(1L, req);
 
         BusinessException exception = assertThrows(BusinessException.class,
                 () -> fcmTokenService.syncFcmToken(1L, req));
@@ -165,14 +160,13 @@ class FcmTokenServiceImplTest {
                 .fcmToken("new-token")
                 .build();
 
-        when(userRepository.findById(2L)).thenReturn(Optional.of(noPushUser));
+        doThrow(new BusinessException(Code.FCM_PUSH_NOT_AGREED))
+                .when(fcmTokenTransactionService).doSyncFcmToken(2L, req);
 
         BusinessException exception = assertThrows(BusinessException.class,
                 () -> fcmTokenService.syncFcmToken(2L, req));
 
         assertEquals(Code.FCM_PUSH_NOT_AGREED, exception.getCode());
-        verify(fcmTokenRepository, never()).findByUserForUpdate(any());
-        verify(fcmTokenRepository, never()).save(any());
     }
 
     @Test
@@ -182,13 +176,11 @@ class FcmTokenServiceImplTest {
                 .fcmToken("concurrent-token")
                 .build();
 
-        when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
-        when(fcmTokenRepository.findByUserForUpdate(testUser)).thenReturn(Optional.empty());
+        doNothing().when(fcmTokenTransactionService).doSyncFcmToken(1L, req);
 
         fcmTokenService.syncFcmToken(1L, req);
 
-        verify(fcmTokenRepository).findByUserForUpdate(testUser);
-        verify(fcmTokenRepository, times(1)).save(any(FcmToken.class));
+        verify(fcmTokenTransactionService).doSyncFcmToken(1L, req);
     }
 
     @Test
@@ -198,12 +190,10 @@ class FcmTokenServiceImplTest {
                 .fcmToken("new-token-after-update")
                 .build();
 
-        when(userRepository.findById(1L)).thenReturn(Optional.of(testUser));
-        when(fcmTokenRepository.findByUserForUpdate(testUser)).thenReturn(Optional.of(existingToken));
+        doNothing().when(fcmTokenTransactionService).doSyncFcmToken(1L, req);
 
         fcmTokenService.syncFcmToken(1L, req);
 
-        verify(fcmTokenRepository).findByUserForUpdate(testUser);
-        assertEquals("new-token-after-update", existingToken.getToken());
+        verify(fcmTokenTransactionService).doSyncFcmToken(1L, req);
     }
 }


### PR DESCRIPTION
## 🎋 작업중인 브랜치 및 이슈

-


## 🔑 주요 변경사항

- REQUIRES_NEW 트랜잭션이 동일 클래스 내 self-invocation으로 인해 적용되지 않던 문제를 해결하기 위해, 
별도의 트랜잭션 전용 빈으로 분리
- 요청 단위 상위 트랜잭션 경계, 독립적인 하위 트랜잭션(REQUIRES_NEW) 으로 동작하도록 개선

https://www.nextblog.me/parkmineum/298303e2-5222-80a5-a4d7-e8fa4a9be6a6


## Check List
- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!