### PR TITLE
[REFACTOR][FIX] 사용자별 멱등성 구분 및 SETNX 경합 문제 해결

### DIFF
--- a/src/main/java/com/gdg/z_meet/domain/order/client/KaKaoPayApiClient.java
+++ b/src/main/java/com/gdg/z_meet/domain/order/client/KaKaoPayApiClient.java
@@ -7,6 +7,8 @@ import com.gdg.z_meet.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
@@ -44,6 +46,11 @@ public class KaKaoPayApiClient {
     
     @Value("${kakao.pay.fail-url}")
     private String failUrl;
+
+    @Bean
+    public RestTemplate restTemplate(RestTemplateBuilder builder) {
+        return builder.build();
+    }
 
     // 카카오 페이 결제 준비 API
     public Optional<KaKaoPayReadyDTO.KakaoApiResponse> requestPaymentReady(

--- a/src/main/java/com/gdg/z_meet/domain/order/client/KaKaoPayApiClient.java
+++ b/src/main/java/com/gdg/z_meet/domain/order/client/KaKaoPayApiClient.java
@@ -47,11 +47,6 @@ public class KaKaoPayApiClient {
     @Value("${kakao.pay.fail-url}")
     private String failUrl;
 
-    @Bean
-    public RestTemplate restTemplate(RestTemplateBuilder builder) {
-        return builder.build();
-    }
-
     // 카카오 페이 결제 준비 API
     public Optional<KaKaoPayReadyDTO.KakaoApiResponse> requestPaymentReady(
             KaKaoPayReadyDTO.Parameter parameter, String orderId, User buyer) {

--- a/src/main/java/com/gdg/z_meet/domain/order/service/KakaoPayApproveService.java
+++ b/src/main/java/com/gdg/z_meet/domain/order/service/KakaoPayApproveService.java
@@ -36,9 +36,12 @@ public class KakaoPayApproveService {
         String lockName = null;
 
         try {
-            // 멱등성 키 검증 (공통 로직)
+            // 멱등성 키 네임스페이스: userId:idempotencyKey
             String currentPayload = parameter.getOrderId() + ":" + parameter.getPgToken();
-            var validationResult = kakaoPayIdempotencyService.validate(idempotencyKey, currentPayload);
+            String namespacedKey = (idempotencyKey == null || idempotencyKey.isEmpty())
+                    ? idempotencyKey
+                    : (parameter.getUserId() + ":" + idempotencyKey);
+            var validationResult = kakaoPayIdempotencyService.validate(namespacedKey, currentPayload);
             
             if (validationResult.isCached()) {
                 return (KaKaoPayApproveDTO.Response) validationResult.getCachedResponse();
@@ -85,6 +88,7 @@ public class KakaoPayApproveService {
             ItemPurchase itemPurchase = KaKaoPayApproveConverter.toItemPurchase(
                     kakaoApiResponse, kakaoPayData, buyer, processResult.team(), processResult.userProfile());
             itemPurchaseRepository.save(itemPurchase);
+            kakaoPayData.setItemPurchase(itemPurchase);
 
             // 5. 결제 상태 업데이트 (승인 완료)
             kakaoPayData.setStatus(PaymentStatus.APPROVED);
@@ -94,7 +98,7 @@ public class KakaoPayApproveService {
 
             // 응답 캐시
             if (idempotencyKey != null && !idempotencyKey.isEmpty()) {
-                kakaoPayIdempotencyService.cacheResponse(idempotencyKey, response);
+                kakaoPayIdempotencyService.cacheResponse(namespacedKey, response);
             }
 
             return response;

--- a/src/main/java/com/gdg/z_meet/domain/order/service/KakaoPayIdempotencyService.java
+++ b/src/main/java/com/gdg/z_meet/domain/order/service/KakaoPayIdempotencyService.java
@@ -46,16 +46,13 @@ public class KakaoPayIdempotencyService {
             return IdempotencyValidationResult.cached(cachedResponse);
         }
 
-        // 409: 처리 중인 요청 확인
-        if (isProcessing(key)) {
+        // SETNX 로 원자적 처리 중 표시 및 경합 상태 해결
+        if (!markAsProcessing(key)) {
             log.warn("동일한 요청이 처리 중입니다 - 멱등성 키: {}", key);
             throw new BusinessException(Code.IDEMPOTENCY_CONFLICT);
         }
 
-        // 새로운 요청으로 표시
-        markAsProcessing(key);
         cachePayload(key, payload);
-
         return IdempotencyValidationResult.processing();
     }
 
@@ -141,24 +138,13 @@ public class KakaoPayIdempotencyService {
     }
 
     /**
-     * 처리 중인 요청인지 확인
+     * 요청을 처리 중으로 표시 (SETNX를 사용한 원자적 연산)
+     * @param key 멱등성 키
+     * @return SETNX 성공 여부 (true: 성공, false: 이미 처리 중)
      */
-    private boolean isProcessing(String key) {
+    private boolean markAsProcessing(String key) {
         if (key == null || key.isEmpty()) {
             return false;
-        }
-
-        String processingKey = PROCESSING_KEY_PREFIX + key;
-        Boolean exists = redisTemplate.hasKey(processingKey);
-        return Boolean.TRUE.equals(exists);
-    }
-
-    /**
-     * 요청을 처리 중으로 표시 (SETNX를 사용한 원자적 연산)
-     */
-    private void markAsProcessing(String key) {
-        if (key == null || key.isEmpty()) {
-            return;
         }
 
         String processingKey = PROCESSING_KEY_PREFIX + key;
@@ -168,8 +154,10 @@ public class KakaoPayIdempotencyService {
         
         if (Boolean.TRUE.equals(setIfAbsent)) {
             log.debug("요청 처리 시작 - 멱등성 키: {}", key);
+            return true;
         } else {
             log.warn("이미 처리 중인 요청 - 멱등성 키: {}", key);
+            return false;
         }
     }
 

--- a/src/main/java/com/gdg/z_meet/domain/order/service/KakaoPayIdempotencyService.java
+++ b/src/main/java/com/gdg/z_meet/domain/order/service/KakaoPayIdempotencyService.java
@@ -138,7 +138,7 @@ public class KakaoPayIdempotencyService {
     }
 
     /**
-     * 요청을 처리 중으로 표시 (SETNX를 사용한 원자적 연산)
+     * 멱등 처리 중임을 표시하는 메서드
      * @param key 멱등성 키
      * @return SETNX 성공 여부 (true: 성공, false: 이미 처리 중)
      */
@@ -149,7 +149,7 @@ public class KakaoPayIdempotencyService {
 
         String processingKey = PROCESSING_KEY_PREFIX + key;
         
-        // SETNX with TTL: 키가 없을 때만 설정하고 TTL을 동시에 적용 (완전 원자적 연산)
+        // 아직 처리 중 표시가 없으면 새로 표시하고, 이미 있으면 중복 요청으로 간주
         Boolean setIfAbsent = redisTemplate.opsForValue().setIfAbsent(processingKey, "processing", PROCESSING_TTL);
         
         if (Boolean.TRUE.equals(setIfAbsent)) {

--- a/src/main/java/com/gdg/z_meet/domain/order/service/KakaoPayReadyService.java
+++ b/src/main/java/com/gdg/z_meet/domain/order/service/KakaoPayReadyService.java
@@ -31,11 +31,15 @@ public class KakaoPayReadyService {
 
     @Transactional
     public KaKaoPayReadyDTO.Response ready(KaKaoPayReadyDTO.Parameter parameter, String idempotencyKey) {
-
         try {
+            // 멱등성 키 네임스페이스: userId:idempotencyKey
+            String namespacedKey = (idempotencyKey == null || idempotencyKey.isEmpty())
+                    ? idempotencyKey
+                    : (parameter.getBuyerId() + ":" + idempotencyKey);
+            
             // 멱등성 키 검증
             String currentPayload = parameter.getTeamId() + ":" + parameter.getProductType() + ":" + parameter.getTotalPrice();
-            var validationResult = kakaoPayIdempotencyService.validate(idempotencyKey, currentPayload);
+            var validationResult = kakaoPayIdempotencyService.validate(namespacedKey, currentPayload);
             
             if (validationResult.isCached()) {
                 return (KaKaoPayReadyDTO.Response) validationResult.getCachedResponse();
@@ -69,14 +73,15 @@ public class KakaoPayReadyService {
 
             // 응답 캐시
             if (idempotencyKey != null && !idempotencyKey.isEmpty()) {
-                kakaoPayIdempotencyService.cacheResponse(idempotencyKey, response);
+                kakaoPayIdempotencyService.cacheResponse(namespacedKey, response);
             }
 
             return response;
         } finally {
             // 멱등성 처리 중 표시 해제
             if (idempotencyKey != null && !idempotencyKey.isEmpty()) {
-                kakaoPayIdempotencyService.unmarkAsProcessing(idempotencyKey);
+                String namespacedKey = parameter.getBuyerId() + ":" + idempotencyKey;
+                kakaoPayIdempotencyService.unmarkAsProcessing(namespacedKey);
             }
         }
     }
@@ -102,4 +107,3 @@ public class KakaoPayReadyService {
         return UUID.randomUUID().toString();
     }
 }
-

--- a/src/main/java/com/gdg/z_meet/domain/order/service/KakaoPayReadyService.java
+++ b/src/main/java/com/gdg/z_meet/domain/order/service/KakaoPayReadyService.java
@@ -31,9 +31,10 @@ public class KakaoPayReadyService {
 
     @Transactional
     public KaKaoPayReadyDTO.Response ready(KaKaoPayReadyDTO.Parameter parameter, String idempotencyKey) {
+        String namespacedKey = null;
         try {
             // 멱등성 키 네임스페이스: userId:idempotencyKey
-            String namespacedKey = (idempotencyKey == null || idempotencyKey.isEmpty())
+            namespacedKey = (idempotencyKey == null || idempotencyKey.isEmpty())
                     ? idempotencyKey
                     : (parameter.getBuyerId() + ":" + idempotencyKey);
             
@@ -80,7 +81,6 @@ public class KakaoPayReadyService {
         } finally {
             // 멱등성 처리 중 표시 해제
             if (idempotencyKey != null && !idempotencyKey.isEmpty()) {
-                String namespacedKey = parameter.getBuyerId() + ":" + idempotencyKey;
                 kakaoPayIdempotencyService.unmarkAsProcessing(namespacedKey);
             }
         }

--- a/src/test/java/com/gdg/z_meet/domain/order/service/KakaoPayIdempotencyServiceTest.java
+++ b/src/test/java/com/gdg/z_meet/domain/order/service/KakaoPayIdempotencyServiceTest.java
@@ -29,6 +29,7 @@ class KakaoPayIdempotencyServiceTest {
 
     private KakaoPayIdempotencyService idempotencyService;
     private static final String TEST_IDEMPOTENCY_KEY = "test-key-123";
+    private static final String TEST_NAMESPACED_KEY = "userId123:test-key-123";
     private static final String TEST_PAYLOAD = "orderId:pgToken";
 
     @BeforeEach
@@ -163,7 +164,8 @@ class KakaoPayIdempotencyServiceTest {
         // given
         when(redisTemplate.opsForValue()).thenReturn(valueOperations);
         when(valueOperations.get(anyString())).thenReturn(null);
-        when(redisTemplate.hasKey("processing:test-key-123")).thenReturn(true);
+        // SETNX 실패 (false 반환 = 이미 처리 중)
+        when(redisTemplate.opsForValue().setIfAbsent(anyString(), any(), any(Duration.class))).thenReturn(false);
 
         // when & then
         assertThatThrownBy(() -> idempotencyService.validate(TEST_IDEMPOTENCY_KEY, TEST_PAYLOAD))
@@ -180,7 +182,6 @@ class KakaoPayIdempotencyServiceTest {
         // given
         when(redisTemplate.opsForValue()).thenReturn(valueOperations);
         when(valueOperations.get(anyString())).thenReturn(null);
-        when(redisTemplate.hasKey(anyString())).thenReturn(false);
         // SETNX 성공 (true 반환)
         when(redisTemplate.opsForValue().setIfAbsent(anyString(), any(), any(Duration.class))).thenReturn(true);
 
@@ -198,16 +199,74 @@ class KakaoPayIdempotencyServiceTest {
         // given
         when(redisTemplate.opsForValue()).thenReturn(valueOperations);
         when(valueOperations.get(anyString())).thenReturn(null);
-        when(redisTemplate.hasKey(anyString())).thenReturn(false);
         // SETNX 실패 (false 반환 = 이미 설정됨)
         when(redisTemplate.opsForValue().setIfAbsent(anyString(), any(), any(Duration.class))).thenReturn(false);
 
+        // when & then
+        assertThatThrownBy(() -> idempotencyService.validate(TEST_IDEMPOTENCY_KEY, TEST_PAYLOAD))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(exception -> {
+                    BusinessException be = (BusinessException) exception;
+                    assertThat(be.getCode()).isEqualTo(Code.IDEMPOTENCY_CONFLICT);
+                });
+    }
+
+    @Test
+    @DisplayName("네임스페이스 포함 멱등성 키 - 정상 처리")
+    void 네임스페이스_포함_멱등성_키_정상_처리() {
+        // given
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        when(valueOperations.get(anyString())).thenReturn(null);
+        when(redisTemplate.opsForValue().setIfAbsent(anyString(), any(), any(Duration.class))).thenReturn(true);
+
         // when
-        var result = idempotencyService.validate(TEST_IDEMPOTENCY_KEY, TEST_PAYLOAD);
+        var result = idempotencyService.validate(TEST_NAMESPACED_KEY, TEST_PAYLOAD);
 
         // then
         assertThat(result.isProcessing()).isTrue();
-        verify(redisTemplate.opsForValue()).setIfAbsent(anyString(), any(), any(Duration.class));
+        verify(redisTemplate.opsForValue()).setIfAbsent(eq("processing:userId123:test-key-123"), eq("processing"), eq(Duration.ofMinutes(5)));
+    }
+
+    @Test
+    @DisplayName("네임스페이스 포함 멱등성 키 - 캐시된 응답 반환")
+    void 네임스페이스_포함_멱등성_키_캐시된_응답_반환() {
+        // given
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        Object cachedResponse = "cached-response";
+        
+        when(valueOperations.get(anyString()))
+                .thenReturn(null)  // 첫 번째: idempotency:userId123:test-key-123:payload (null)
+                .thenReturn(cachedResponse);  // 두 번째: idempotency:userId123:test-key-123 (캐시된 응답)
+
+        // when
+        var result = idempotencyService.validate(TEST_NAMESPACED_KEY, TEST_PAYLOAD);
+
+        // then
+        assertThat(result.isCached()).isTrue();
+        assertThat(result.getCachedResponse()).isEqualTo(cachedResponse);
+    }
+
+    @Test
+    @DisplayName("다른 사용자의 동일한 멱등성 키 - 충돌 없음")
+    void 다른_사용자의_동일한_멱등성_키_충돌_없음() {
+        // given
+        String anotherUserKey = "userId456:test-key-123";
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        when(valueOperations.get(anyString())).thenReturn(null);
+        when(redisTemplate.opsForValue().setIfAbsent(anyString(), any(), any(Duration.class))).thenReturn(true);
+
+        // when - 첫 번째 사용자
+        var result1 = idempotencyService.validate(TEST_NAMESPACED_KEY, TEST_PAYLOAD);
+        
+        // when - 두 번째 사용자
+        var result2 = idempotencyService.validate(anotherUserKey, TEST_PAYLOAD);
+
+        // then - 두 요청 모두 성공
+        assertThat(result1.isProcessing()).isTrue();
+        assertThat(result2.isProcessing()).isTrue();
+        // 서로 다른 키로 저장됨
+        verify(redisTemplate.opsForValue()).setIfAbsent(eq("processing:userId123:test-key-123"), any(), any());
+        verify(redisTemplate.opsForValue()).setIfAbsent(eq("processing:userId456:test-key-123"), any(), any());
     }
 }
 


### PR DESCRIPTION
## 🎋 작업중인 브랜치 및 이슈

-


## 🔑 주요 변경사항

- idempotencyKey에 userId를 네임스페이스로 추가하여(userId:idempotencyKey),사용자 단위로 멱등성을 구분
- 경합 상태: isProcessing() 체크와 markAsProcessing() 사이에 다른 스레드가 SETNX 성공하는 경우
- 중복 처리: SETNX 실패 시에도 processing() 반환하던 문제
- 원자성: SETNX 결과로 즉시 409 에러 발생

동시 요청에서 정확히 하나만 처리되고 나머지는 409 에러 처리되도록 문제해결 및 개선

## Check List
- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **New Features**
  * 사용자별 네임스페이스 멱등성 키 도입으로 각 사용자-요청을 고유하게 구분

* **Bug Fixes**
  * 멱등성 검증·캐시·해제 흐름을 네임스페이스 키에 맞춰 일관화
  * 멱등성 처리의 원자적 잠금 도입으로 중복 승인 충돌 감소
  * 결제 승인 시 생성된 구매 정보를 결제 데이터에 연동

* **Tests**
  * 네임스페이스 멱등성 및 잠금/캐시 동작을 검증하는 테스트 확장
<!-- end of auto-generated comment: release notes by coderabbit.ai -->