### PR TITLE
[REFACTOR] 알림 종류에 따라 메시지 큐 라우팅 기능 리팩토링

### DIFF
--- a/docker-compose.worker-mq.yml
+++ b/docker-compose.worker-mq.yml
@@ -20,8 +20,33 @@ services:
       retries: 3
     restart: unless-stopped
 
-  backend-worker:
-    container_name: backend-worker
+  backend-worker-1:
+    container_name: backend-worker-1
+    image: ${DOCKERHUB_USERNAME}/zimeet:latest
+    env_file:
+      - .env
+    environment:
+      - SPRING_PROFILES_ACTIVE=prod,worker
+      - MYSQL_USER=${PROD_DB_USERNAME}
+      - MYSQL_PASSWORD=${PROD_DB_PASSWORD}
+      - MYSQL_URL=jdbc:mysql://${PROD_DB_ENDPOINT}:3306/${PROD_DB_NAME}?serverTimezone=UTC&sslMode=PREFERRED&allowPublicKeyRetrieval=true
+    volumes:
+      - ./firebase-adminsdk.json:/app/firebase-adminsdk.json:ro
+    networks:
+      - zimeet_network
+    depends_on:
+      rabbitmq:
+        condition: service_healthy
+    restart: unless-stopped
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:8080/api/health" ]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 90s
+
+  backend-worker-2:
+    container_name: backend-worker-2
     image: ${DOCKERHUB_USERNAME}/zimeet:latest
     env_file:
       - .env

--- a/src/main/java/com/gdg/z_meet/domain/fcm/service/consumer/FcmMessageConsumerImpl.java
+++ b/src/main/java/com/gdg/z_meet/domain/fcm/service/consumer/FcmMessageConsumerImpl.java
@@ -21,8 +21,8 @@ import java.util.List;
 import java.util.Set;
 
 /**
- *  Message Consumer 로,
- *  RabbitMQ 에서 메시지를 꺼내 FCM 관련 로직 처리
+ * Message Consumer 로,
+ * RabbitMQ 에서 메시지를 꺼내 FCM 관련 로직 처리
  */
 @Service
 @RequiredArgsConstructor
@@ -33,26 +33,43 @@ public class FcmMessageConsumerImpl implements FcmMessageConsumer {
     private final FcmTokenRepository fcmTokenRepository;
 
     /**
-     *  무효한 토큰으로 간주할 에러 코드들
+     * 무효한 토큰으로 간주할 에러 코드들
      */
     private static final Set<String> DELETABLE_ERROR_CODES = Set.of(
             "unregistered",
-            "invalid-argument", 
+            "invalid-argument",
             "invalid-arguments",
             "registration-token-not-registered",
             "messaging/invalid-registration-token",
-            "messaging/registration-token-not-registered"
-    );
+            "messaging/registration-token-not-registered");
 
     /**
-     *  FCM 전용 큐에 바인딩
-     *  @RabbitListener(queues = RabbitMqConfig.FCM_QUEUE) : Spring 이 알아서 메시지를 꺼냄 → JSON 역직렬화 → fcmMessage 객체로 바인딩 → 메서드 실행
+     * FCM 전용 큐에 바인딩
+     * 
+     * @RabbitListener(queues = RabbitMqConfig.FCM_QUEUE) : Spring 이 알아서 메시지를 꺼냄 →
+     *                        JSON 역직렬화 → fcmMessage 객체로 바인딩 → 메서드 실행
      */
-    @RabbitListener(queues = RabbitMqConfig.FCM_QUEUE)
+    /**
+     * Broadcast Queue Listener
+     */
+    @RabbitListener(queues = RabbitMqConfig.FCM_BROADCAST_QUEUE)
     @Transactional
+    public void consumeBroadcastMessage(FcmMessageRequest fcmMessage) {
+        processFcmMessage(fcmMessage);
+    }
+
+    /**
+     * Single Queue Listener
+     */
+    @RabbitListener(queues = RabbitMqConfig.FCM_SINGLE_QUEUE)
+    @Transactional
+    public void consumeSingleMessage(FcmMessageRequest fcmMessage) {
+        processFcmMessage(fcmMessage);
+    }
+
     @Override
     public void processFcmMessage(FcmMessageRequest fcmMessage) {
-        log.info("FCM 메시지 처리 시작: messageId={}, type={}", 
+        log.info("FCM 메시지 처리 시작: messageId={}, type={}",
                 fcmMessage.getMessageId(), fcmMessage.getType());
 
         try {
@@ -61,27 +78,28 @@ public class FcmMessageConsumerImpl implements FcmMessageConsumer {
                 case TEST -> processTestMessage(fcmMessage);
                 case SINGLE -> processSingleMessage(fcmMessage);
             }
-            
+
             log.info("FCM 메시지 처리 완료: messageId={}", fcmMessage.getMessageId());
-            
+
         } catch (Exception e) {
-            log.error("FCM 메시지 처리 실패: messageId={}, error={}", 
+            log.error("FCM 메시지 처리 실패: messageId={}, error={}",
                     fcmMessage.getMessageId(), e.getMessage(), e);
-            throw new AmqpRejectAndDontRequeueException("FCM 메시지 처리 실패로 재큐 방지: messageId=" + fcmMessage.getMessageId(), e);
+            throw new AmqpRejectAndDontRequeueException("FCM 메시지 처리 실패로 재큐 방지: messageId=" + fcmMessage.getMessageId(),
+                    e);
         }
     }
 
     private void processBroadcastMessage(FcmMessageRequest fcmMessage) {
         List<FcmToken> tokens = fcmTokenRepository.findAllByUserPushAgreeTrue();
-        
+
         if (tokens.isEmpty()) {
             log.info("브로드캐스트 대상 사용자가 없습니다.");
             return;
         }
-        
+
         for (FcmToken userToken : tokens) {
-            sendFcmMessage(userToken.getToken(), userToken.getUser().getId(), 
-                         fcmMessage.getTitle(), fcmMessage.getBody(), userToken);
+            sendFcmMessage(userToken.getToken(), userToken.getUser().getId(),
+                    fcmMessage.getTitle(), fcmMessage.getBody(), userToken);
         }
     }
 
@@ -90,18 +108,18 @@ public class FcmMessageConsumerImpl implements FcmMessageConsumer {
             log.warn("단일 메시지의 사용자 ID가 없습니다.");
             return;
         }
-        
+
         // userId로 FCM 토큰 조회
         User user = User.builder().id(fcmMessage.getUserId()).build();
         FcmToken userToken = fcmTokenRepository.findByUser(user).orElse(null);
-        
+
         if (userToken == null) {
             log.warn("사용자의 FCM 토큰을 찾을 수 없습니다: userId={}", fcmMessage.getUserId());
             return;
         }
-        
-        sendFcmMessage(userToken.getToken(), fcmMessage.getUserId(), 
-                     fcmMessage.getTitle(), fcmMessage.getBody(), userToken);
+
+        sendFcmMessage(userToken.getToken(), fcmMessage.getUserId(),
+                fcmMessage.getTitle(), fcmMessage.getBody(), userToken);
     }
 
     private void processTestMessage(FcmMessageRequest fcmMessage) {
@@ -119,7 +137,7 @@ public class FcmMessageConsumerImpl implements FcmMessageConsumer {
 
     private void sendFcmMessage(String token, Long userId, String title, String body, FcmToken tokenEntity) {
         if (!isValidToken(token)) {
-            log.warn("FCM 토큰이 유효하지 않습니다: userId={}, token={}", userId, 
+            log.warn("FCM 토큰이 유효하지 않습니다: userId={}, token={}", userId,
                     token != null ? maskToken(token) : "null");
             return;
         }
@@ -129,7 +147,7 @@ public class FcmMessageConsumerImpl implements FcmMessageConsumer {
         try {
             String response = FirebaseMessaging.getInstance().send(message);
             log.info("FCM 전송 성공: userId={}, response={}", userId, response);
-            
+
         } catch (FirebaseMessagingException e) {
             log.warn("FCM 전송 실패: userId={}, error={}", userId, e.getMessage());
 
@@ -139,18 +157,18 @@ public class FcmMessageConsumerImpl implements FcmMessageConsumer {
             }
         }
     }
-    
+
     private boolean isValidToken(String token) {
         return token != null && !token.isBlank() && !"null".equalsIgnoreCase(token);
     }
-    
+
     private String maskToken(String token) {
         if (token == null || token.length() <= 10) {
             return "***";
         }
         return token.substring(0, 10) + "...";
     }
-    
+
     private Message buildFcmMessage(String token, String title, String body) {
         return Message.builder()
                 .setToken(token)
@@ -164,22 +182,22 @@ public class FcmMessageConsumerImpl implements FcmMessageConsumer {
     private void handleInvalidToken(FirebaseMessagingException e, FcmToken tokenEntity, String token, Long userId) {
         String errorCode = e.getErrorCode() != null ? e.getErrorCode().toString().toLowerCase() : "";
         String errorMessage = e.getMessage() != null ? e.getMessage().toLowerCase() : "";
-        
+
         // 에러 코드 또는 에러 메시지로 판단
         if (isDeleteableErrorCode(errorCode) || isDeleteableErrorMessage(errorMessage)) {
             fcmTokenRepository.delete(tokenEntity);
-            log.warn("무효한 FCM 토큰 삭제: token={}, userId={}, errorCode={}, message={}", 
+            log.warn("무효한 FCM 토큰 삭제: token={}, userId={}, errorCode={}, message={}",
                     maskToken(token), userId, errorCode, e.getMessage());
         }
     }
-    
+
     private boolean isDeleteableErrorCode(String errorCode) {
         return DELETABLE_ERROR_CODES.contains(errorCode);
     }
-    
+
     private boolean isDeleteableErrorMessage(String errorMessage) {
-        return errorMessage.contains("unregistered") || 
-               errorMessage.contains("not-registered") ||
-               errorMessage.contains("invalid") && errorMessage.contains("token");
+        return errorMessage.contains("unregistered") ||
+                errorMessage.contains("not-registered") ||
+                errorMessage.contains("invalid") && errorMessage.contains("token");
     }
 }

--- a/src/main/java/com/gdg/z_meet/domain/fcm/service/producer/FcmMessageProducerImpl.java
+++ b/src/main/java/com/gdg/z_meet/domain/fcm/service/producer/FcmMessageProducerImpl.java
@@ -12,89 +12,86 @@ import java.util.List;
 import java.util.UUID;
 
 /**
- *  Message Publish Producer 로,
- *  Message 를 발행하여 RabbitMQ 로 보낸다.
+ * Message Publish Producer 로,
+ * Message 를 발행하여 RabbitMQ 로 보낸다.
  */
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class FcmMessageProducerImpl implements FcmMessageProducer {
 
-    private final RabbitTemplate rabbitTemplate;
+        private final RabbitTemplate rabbitTemplate;
 
-    @Override
-    public void sendBroadcastMessage(String title, String body) {
+        @Override
+        public void sendBroadcastMessage(String title, String body) {
 
-        /**
-         *  FcmMessageRequest 메시지 요청 객체
-         */
-        FcmMessageRequest message = FcmMessageRequest.builder()
-                .messageId(UUID.randomUUID().toString())
-                .type(FcmMessageRequest.FcmType.BROADCAST)
-                .title(title)
-                .body(body)
-                .createdAt(LocalDateTime.now())
-                .build();
+                /**
+                 * FcmMessageRequest 메시지 요청 객체
+                 */
+                FcmMessageRequest message = FcmMessageRequest.builder()
+                                .messageId(UUID.randomUUID().toString())
+                                .type(FcmMessageRequest.FcmType.BROADCAST)
+                                .title(title)
+                                .body(body)
+                                .createdAt(LocalDateTime.now())
+                                .build();
 
-        /**
-         *  RabbitMQ 에 메시지 발행
-         */
-        rabbitTemplate.convertAndSend(
-                RabbitMqConfig.FCM_EXCHANGE,
-                RabbitMqConfig.FCM_ROUTING_KEY,
-                message
-        );
+                /**
+                 * RabbitMQ 에 메시지 발행
+                 */
+                rabbitTemplate.convertAndSend(
+                                RabbitMqConfig.FCM_EXCHANGE,
+                                RabbitMqConfig.FCM_BROADCAST_ROUTING_KEY,
+                                message);
 
-        log.info("브로드캐스트 FCM 메시지를 큐에 전송했습니다. messageId: {}, title: {}", 
-                message.getMessageId(), title);
-    }
-
-    @Override
-    public void sendSingleMessage(Long userId, String title, String body) {
-        FcmMessageRequest message = FcmMessageRequest.builder()
-                .messageId(UUID.randomUUID().toString())
-                .type(FcmMessageRequest.FcmType.SINGLE)
-                .title(title)
-                .body(body)
-                .userId(userId)
-                .createdAt(LocalDateTime.now())
-                .build();
-
-        rabbitTemplate.convertAndSend(
-                RabbitMqConfig.FCM_EXCHANGE,
-                RabbitMqConfig.FCM_ROUTING_KEY,
-                message
-        );
-
-        log.info("단일 FCM 메시지를 큐에 전송했습니다. messageId: {}, userId: {}",
-                message.getMessageId(), userId);
-    }
-
-    @Override
-    public void sendTestMessage(Long userId, String fcmToken, String title, String body) {
-
-        if (fcmToken == null || fcmToken.isBlank()) {
-            log.warn("테스트 FCM 메시지를 큐에 전송하지 않습니다. userId={}, 사유=FCM 토큰 누락", userId);
-            return;
+                log.info("브로드캐스트 FCM 메시지를 큐에 전송했습니다. messageId: {}, title: {}",
+                                message.getMessageId(), title);
         }
 
-        FcmMessageRequest message = FcmMessageRequest.builder()
-                .messageId(UUID.randomUUID().toString())
-                .type(FcmMessageRequest.FcmType.TEST)
-                .title(title)
-                .body(body)
-                .userId(userId)
-                .fcmTokens(List.of(fcmToken))
-                .createdAt(LocalDateTime.now())
-                .build();
+        @Override
+        public void sendSingleMessage(Long userId, String title, String body) {
+                FcmMessageRequest message = FcmMessageRequest.builder()
+                                .messageId(UUID.randomUUID().toString())
+                                .type(FcmMessageRequest.FcmType.SINGLE)
+                                .title(title)
+                                .body(body)
+                                .userId(userId)
+                                .createdAt(LocalDateTime.now())
+                                .build();
 
-        rabbitTemplate.convertAndSend(
-                RabbitMqConfig.FCM_EXCHANGE,
-                RabbitMqConfig.FCM_ROUTING_KEY,
-                message
-        );
+                rabbitTemplate.convertAndSend(
+                                RabbitMqConfig.FCM_EXCHANGE,
+                                RabbitMqConfig.FCM_SINGLE_ROUTING_KEY,
+                                message);
 
-        log.info("테스트 FCM 메시지를 큐에 전송했습니다. messageId: {}, userId: {}", 
-                message.getMessageId(), userId);
-    }
+                log.info("단일 FCM 메시지를 큐에 전송했습니다. messageId: {}, userId: {}",
+                                message.getMessageId(), userId);
+        }
+
+        @Override
+        public void sendTestMessage(Long userId, String fcmToken, String title, String body) {
+
+                if (fcmToken == null || fcmToken.isBlank()) {
+                        log.warn("테스트 FCM 메시지를 큐에 전송하지 않습니다. userId={}, 사유=FCM 토큰 누락", userId);
+                        return;
+                }
+
+                FcmMessageRequest message = FcmMessageRequest.builder()
+                                .messageId(UUID.randomUUID().toString())
+                                .type(FcmMessageRequest.FcmType.TEST)
+                                .title(title)
+                                .body(body)
+                                .userId(userId)
+                                .fcmTokens(List.of(fcmToken))
+                                .createdAt(LocalDateTime.now())
+                                .build();
+
+                rabbitTemplate.convertAndSend(
+                                RabbitMqConfig.FCM_EXCHANGE,
+                                RabbitMqConfig.FCM_SINGLE_ROUTING_KEY,
+                                message);
+
+                log.info("테스트 FCM 메시지를 큐에 전송했습니다. messageId: {}, userId: {}",
+                                message.getMessageId(), userId);
+        }
 }

--- a/src/main/java/com/gdg/z_meet/global/config/RabbitMqConfig.java
+++ b/src/main/java/com/gdg/z_meet/global/config/RabbitMqConfig.java
@@ -14,18 +14,23 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class RabbitMqConfig {
-    
-    public static final String FCM_EXCHANGE = "fcm.exchange";      // 메시지 컨슈머 라우터
-    public static final String FCM_QUEUE = "fcm.queue";            // 메시지 적재 큐
-    public static final String FCM_ROUTING_KEY = "fcm.send";       // Queue 로 메시지를 보내는데 쓰이는 키
-    
+
+    public static final String FCM_EXCHANGE = "fcm.exchange"; // 메시지 컨슈머 라우터
+
+    // Broadcast (전체 발송)
+    public static final String FCM_BROADCAST_QUEUE = "fcm.broadcast.queue";
+    public static final String FCM_BROADCAST_ROUTING_KEY = "fcm.broadcast.send";
+
+    // Single (단건/테스트 발송)
+    public static final String FCM_SINGLE_QUEUE = "fcm.single.queue";
+    public static final String FCM_SINGLE_ROUTING_KEY = "fcm.single.send";
+
     public static final String FCM_DLX_EXCHANGE = "fcm.dlx.exchange";
     public static final String FCM_DLQ_QUEUE = "fcm.dlq.queue";
     public static final String FCM_DLQ_ROUTING_KEY = "fcm.dlq";
 
-
     /**
-     *  라우팅 키가 정확히 일치해야 Queue 로 전달, 서버 재시작해도 큐 유지, 사용자 빠져나가도 큐 유지
+     * 라우팅 키가 정확히 일치해야 Queue 로 전달, 서버 재시작해도 큐 유지, 사용자 빠져나가도 큐 유지
      */
     @Bean
     public DirectExchange fcmExchange() {
@@ -33,11 +38,11 @@ public class RabbitMqConfig {
     }
 
     /**
-     *  발행된 메시지가 TTL 을 초과하면, Dead Letter 처리
+     * Broadcast Queue
      */
     @Bean
-    public Queue fcmQueue() {
-        return QueueBuilder.durable(FCM_QUEUE)
+    public Queue fcmBroadcastQueue() {
+        return QueueBuilder.durable(FCM_BROADCAST_QUEUE)
                 .withArgument("x-dead-letter-exchange", FCM_DLX_EXCHANGE)
                 .withArgument("x-dead-letter-routing-key", FCM_DLQ_ROUTING_KEY)
                 .withArgument("x-message-ttl", 300000) // 5분 TTL
@@ -45,8 +50,25 @@ public class RabbitMqConfig {
     }
 
     @Bean
-    public Binding fcmBinding() {
-        return BindingBuilder.bind(fcmQueue()).to(fcmExchange()).with(FCM_ROUTING_KEY);
+    public Binding fcmBroadcastBinding() {
+        return BindingBuilder.bind(fcmBroadcastQueue()).to(fcmExchange()).with(FCM_BROADCAST_ROUTING_KEY);
+    }
+
+    /**
+     * Single Queue
+     */
+    @Bean
+    public Queue fcmSingleQueue() {
+        return QueueBuilder.durable(FCM_SINGLE_QUEUE)
+                .withArgument("x-dead-letter-exchange", FCM_DLX_EXCHANGE)
+                .withArgument("x-dead-letter-routing-key", FCM_DLQ_ROUTING_KEY)
+                .withArgument("x-message-ttl", 300000) // 5분 TTL
+                .build();
+    }
+
+    @Bean
+    public Binding fcmSingleBinding() {
+        return BindingBuilder.bind(fcmSingleQueue()).to(fcmExchange()).with(FCM_SINGLE_ROUTING_KEY);
     }
 
     /**
@@ -79,8 +101,7 @@ public class RabbitMqConfig {
 
     @Bean
     public org.springframework.amqp.support.converter.DefaultClassMapper classMapper() {
-        org.springframework.amqp.support.converter.DefaultClassMapper classMapper = 
-            new org.springframework.amqp.support.converter.DefaultClassMapper();
+        org.springframework.amqp.support.converter.DefaultClassMapper classMapper = new org.springframework.amqp.support.converter.DefaultClassMapper();
         classMapper.setTrustedPackages("java.util", "java.lang", "com.gdg.z_meet.domain.fcm.dto");
         return classMapper;
     }

--- a/src/test/java/com/gdg/z_meet/domain/fcm/unit/service/producer/FcmMessageProducerImplTest.java
+++ b/src/test/java/com/gdg/z_meet/domain/fcm/unit/service/producer/FcmMessageProducerImplTest.java
@@ -3,8 +3,6 @@ package com.gdg.z_meet.domain.fcm.unit.service.producer;
 import com.gdg.z_meet.domain.fcm.dto.FcmMessageRequest;
 import com.gdg.z_meet.domain.fcm.service.producer.FcmMessageProducerImpl;
 import com.gdg.z_meet.global.config.RabbitMqConfig;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -12,7 +10,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -41,15 +38,14 @@ class FcmMessageProducerImplTest {
 
         verify(rabbitTemplate).convertAndSend(
                 eq(RabbitMqConfig.FCM_EXCHANGE),
-                eq(RabbitMqConfig.FCM_ROUTING_KEY),
+                eq(RabbitMqConfig.FCM_BROADCAST_ROUTING_KEY),
                 argThat((FcmMessageRequest message) -> {
                     return message.getType() == FcmMessageRequest.FcmType.BROADCAST &&
                             message.getTitle().equals(title) &&
                             message.getBody().equals(body) &&
                             message.getMessageId() != null &&
                             message.getCreatedAt() != null;
-                })
-        );
+                }));
     }
 
     @Test
@@ -63,7 +59,7 @@ class FcmMessageProducerImplTest {
 
         verify(rabbitTemplate).convertAndSend(
                 eq(RabbitMqConfig.FCM_EXCHANGE),
-                eq(RabbitMqConfig.FCM_ROUTING_KEY),
+                eq(RabbitMqConfig.FCM_SINGLE_ROUTING_KEY),
                 argThat((FcmMessageRequest message) -> {
                     return message.getType() == FcmMessageRequest.FcmType.TEST &&
                             message.getTitle().equals(title) &&
@@ -72,8 +68,7 @@ class FcmMessageProducerImplTest {
                             message.getFcmTokens().equals(List.of(fcmToken)) &&
                             message.getMessageId() != null &&
                             message.getCreatedAt() != null;
-                })
-        );
+                }));
     }
 
     @Test
@@ -86,7 +81,7 @@ class FcmMessageProducerImplTest {
 
         verify(rabbitTemplate).convertAndSend(
                 eq(RabbitMqConfig.FCM_EXCHANGE),
-                eq(RabbitMqConfig.FCM_ROUTING_KEY),
+                eq(RabbitMqConfig.FCM_SINGLE_ROUTING_KEY),
                 argThat((FcmMessageRequest message) -> {
                     return message.getType() == FcmMessageRequest.FcmType.SINGLE &&
                             message.getTitle().equals(title) &&
@@ -94,8 +89,7 @@ class FcmMessageProducerImplTest {
                             message.getUserId().equals(userId) &&
                             message.getMessageId() != null &&
                             message.getCreatedAt() != null;
-                })
-        );
+                }));
     }
 
     @Test
@@ -107,12 +101,11 @@ class FcmMessageProducerImplTest {
 
         verify(rabbitTemplate).convertAndSend(
                 eq(RabbitMqConfig.FCM_EXCHANGE),
-                eq(RabbitMqConfig.FCM_ROUTING_KEY),
+                eq(RabbitMqConfig.FCM_BROADCAST_ROUTING_KEY),
                 argThat((FcmMessageRequest message) -> {
                     return message.getTitle().equals(emptyTitle) &&
                             message.getBody().equals(emptyBody);
-                })
-        );
+                }));
     }
 
     @Test
@@ -126,12 +119,11 @@ class FcmMessageProducerImplTest {
 
         verify(rabbitTemplate).convertAndSend(
                 eq(RabbitMqConfig.FCM_EXCHANGE),
-                eq(RabbitMqConfig.FCM_ROUTING_KEY),
+                eq(RabbitMqConfig.FCM_SINGLE_ROUTING_KEY),
                 argThat((FcmMessageRequest message) -> {
                     return message.getUserId() == null &&
                             message.getFcmTokens().equals(List.of(fcmToken));
-                })
-        );
+                }));
     }
 
     @Test
@@ -179,14 +171,13 @@ class FcmMessageProducerImplTest {
 
         verify(rabbitTemplate).convertAndSend(
                 eq(RabbitMqConfig.FCM_EXCHANGE),
-                eq(RabbitMqConfig.FCM_ROUTING_KEY),
+                eq(RabbitMqConfig.FCM_BROADCAST_ROUTING_KEY),
                 argThat((FcmMessageRequest message) -> {
                     return message.getTitle() == null &&
                             message.getBody() == null &&
                             message.getMessageId() != null &&
                             message.getCreatedAt() != null;
-                })
-        );
+                }));
     }
 
     @Test
@@ -197,7 +188,7 @@ class FcmMessageProducerImplTest {
         doThrow(new RuntimeException("RabbitMQ 연결 실패"))
                 .when(rabbitTemplate).convertAndSend(anyString(), anyString(), any(FcmMessageRequest.class));
 
-        assertThrows(RuntimeException.class, 
+        assertThrows(RuntimeException.class,
                 () -> fcmMessageProducer.sendBroadcastMessage(title, body));
     }
 
@@ -213,26 +204,29 @@ class FcmMessageProducerImplTest {
         // messageId가 다른지 확인 (UUID이므로 매번 달라야 함)
         verify(rabbitTemplate, times(2)).convertAndSend(
                 eq(RabbitMqConfig.FCM_EXCHANGE),
-                eq(RabbitMqConfig.FCM_ROUTING_KEY),
-                argThat((FcmMessageRequest message) -> message.getMessageId() != null)
-        );
+                eq(RabbitMqConfig.FCM_BROADCAST_ROUTING_KEY),
+                argThat((FcmMessageRequest message) -> message.getMessageId() != null));
     }
 
     @Test
     void FCM메시지_타입별_검증() {
         // BROADCAST 타입
         fcmMessageProducer.sendBroadcastMessage("브로드캐스트", "모든사용자");
-        
+
         // SINGLE 타입
         fcmMessageProducer.sendSingleMessage(1L, "단일메시지", "특정사용자");
-        
+
         // TEST 타입
         fcmMessageProducer.sendTestMessage(1L, "test-token", "테스트", "테스트메시지");
 
-        verify(rabbitTemplate, times(3)).convertAndSend(
+        verify(rabbitTemplate).convertAndSend(
                 eq(RabbitMqConfig.FCM_EXCHANGE),
-                eq(RabbitMqConfig.FCM_ROUTING_KEY),
-                any(FcmMessageRequest.class)
-        );
+                eq(RabbitMqConfig.FCM_BROADCAST_ROUTING_KEY),
+                any(FcmMessageRequest.class));
+
+        verify(rabbitTemplate, times(2)).convertAndSend(
+                eq(RabbitMqConfig.FCM_EXCHANGE),
+                eq(RabbitMqConfig.FCM_SINGLE_ROUTING_KEY),
+                any(FcmMessageRequest.class));
     }
 }


### PR DESCRIPTION
## 🎋 작업중인 브랜치 및 이슈

-


## 🔑 주요 변경사항

### RabbitMQ
- Broadcast Queue: fcm.broadcast.queue (라우팅 키: fcm.broadcast.send) : 전체 공지사항 등 대량 발송용
- Single Queue: fcm.single.queue (라우팅 키: fcm.single.send) : 채팅, 결제 완료 등 즉시성이 중요한 개인 알림용

### Producer  : 메시지를 발행할 때 종류에 따라 다른 라우팅 키를 사용하도록 변경
- sendBroadcastMessage → fcm.broadcast.send 로 발행
- sendSingleMessage → fcm.single.send 로 발행

### Consumer : 기존의 단일 리스너 메서드를 두 개로 분리하여 병렬 처리가 가능하도록 변경 
- consumeBroadcastMessage : 브로드캐스트 큐만 전담하여 리스닝
- consumeSingleMessage : 단건 큐만 전담하여 리스닝
- 브로드캐스트 알림이 10만 개 쌓여 있어도, 단건 알림은 비어 있는 Single Queue를 통해 즉시 Consumer에게 전달되어 처리됩니다. (Head-of-Line Blocking 해결)

## Check List
- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **인프라 개선**
  * 메시지 처리 워커를 다중 인스턴스로 확장하여 처리 성능 향상
  * 헬스 체크 및 자동 재시작 정책 추가로 시스템 안정성 개선
  * Firebase 인증 설정 및 데이터베이스 연결 보안 강화

* **리팩토링**
  * 방송형 메시지와 개별 메시지 처리 경로 분리로 시스템 효율성 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->